### PR TITLE
feat: Add table support for TipTap editor

### DIFF
--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -209,6 +209,30 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
         "title": _("Table"),
         "icon": '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-table" viewBox="0 0 16 16"><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm15 2h-4v3h4zm0 4h-4v3h4zm0 4h-4v3h3a1 1 0 0 0 1-1zm-5 3v-3H6v3zm-5 0v-3H1v2a1 1 0 0 0 1 1zm-4-4h4V8H1zm0-4h4V4H1zm5-3v3h4V4zm4 4H6v3h4z"/></svg>',
     },
+    "addRowBefore": {
+        "title": _("Add row before"),
+    },
+    "addRowAfter": {
+        "title": _("Add row after"),
+    },
+    "addColumnBefore": {
+        "title": _("Add column before"),
+    },
+    "addColumnAfter": {
+        "title": _("Add column after"),
+    },
+    "deleteRow": {
+        "title": _("Delete row"),
+    },
+    "deleteColumn": {
+        "title": _("Delete column"),
+    },
+    "deleteTable": {
+        "title": _("Delete table"),
+    },
+    "mergeOrSplit": {
+        "title": _("Merge or split cells"),
+    },
     "Code": {
         "title": _("Code"),
         "icon": '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-code" viewBox="0 0 16 16">\n'

--- a/djangocms_text/locale/ar/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/ar/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Arabic (https://www.transifex.com/divio/teams/58664/ar/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/bn/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/bn/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Bengali (https://www.transifex.com/divio/teams/58664/bn/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/ca/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/ca/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Catalan (https://www.transifex.com/divio/teams/58664/ca/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/cs/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/cs/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Czech (https://www.transifex.com/divio/teams/58664/cs/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/da/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/da/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Danish (https://www.transifex.com/divio/teams/58664/da/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/de/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/de/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2024\n"
 "Language-Team: German (https://app.transifex.com/divio/teams/58664/de/)\n"
@@ -146,74 +146,106 @@ msgid "Table"
 msgstr "Tabelle"
 
 #: editors.py:213
+msgid "Add row before"
+msgstr "Neue Zeile oberhalb"
+
+#: editors.py:216
+msgid "Add row after"
+msgstr "Neue Zeile unterhalb"
+
+#: editors.py:219
+msgid "Add column before"
+msgstr "Neue Spalte links"
+
+#: editors.py:222
+msgid "Add column after"
+msgstr "Neue Spalte rechts"
+
+#: editors.py:225
+msgid "Delete row"
+msgstr "Zeile löschen"
+
+#: editors.py:228
+msgid "Delete column"
+msgstr "Spalte löschen"
+
+#: editors.py:231
+msgid "Delete table"
+msgstr "Tabelle löschen"
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr "Zellen verbinden oder spalten"
+
+#: editors.py:237
 msgid "Code"
 msgstr "Code"
 
-#: editors.py:219
+#: editors.py:243
 msgid "Small"
 msgstr "Klein"
 
-#: editors.py:222
+#: editors.py:246
 msgid "Keyboard input"
 msgstr "Tastatureingabe"
 
-#: editors.py:228
+#: editors.py:252
 msgid "Code block"
 msgstr "Codeblock"
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr "Überschrift 4"
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr "Überschrift 5"
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr "Überschrift 6"
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr "Absatz"
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr "Anker"
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr "Stile"
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr "Schriftart"
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr "Schriftgröße"
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS-Bausteine"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "Baustein bearbeiten"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "Baustein hinzufügen"
 

--- a/djangocms_text/locale/el/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/el/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Greek (https://www.transifex.com/divio/teams/58664/el/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/en/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,80 +148,112 @@ msgid "Table"
 msgstr "Table"
 
 #: editors.py:213
+msgid "Add row before"
+msgstr "Add row before"
+
+#: editors.py:216
+msgid "Add row after"
+msgstr "Add row after"
+
+#: editors.py:219
+msgid "Add column before"
+msgstr "Add column before"
+
+#: editors.py:222
+msgid "Add column after"
+msgstr "Add column after"
+
+#: editors.py:225
+msgid "Delete row"
+msgstr "Delete row"
+
+#: editors.py:228
+msgid "Delete column"
+msgstr "Delete column"
+
+#: editors.py:231
+msgid "Delete table"
+msgstr "Delete table"
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr "Merge or split cells"
+
+#: editors.py:237
 msgid "Code"
 msgstr "Code"
 
-#: editors.py:219
+#: editors.py:243
 msgid "Small"
 msgstr "Small"
 
-#: editors.py:222
+#: editors.py:246
 msgid "Keyboard input"
 msgstr "Keyboard input"
 
-#: editors.py:228
+#: editors.py:252
 msgid "Code block"
 msgstr "Code block"
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr "Heading 1"
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr "Heading 2"
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr "Heading 3"
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr "Heading 4"
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr "Heading 5"
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr "Heading 6"
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr "Paragraph"
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr "Anchor"
 
-#: editors.py:280
+#: editors.py:304
 #, fuzzy
 #| msgid "Blockquote"
 msgid "Block format"
 msgstr "Blockquote"
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr "Styles"
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr "Font"
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr "Font size"
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS Plugins"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "Edit CMS Plugin"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "Add CMS Plugin"
 

--- a/djangocms_text/locale/es/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/es/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2024\n"
 "Language-Team: Spanish (https://app.transifex.com/divio/teams/58664/es/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS Plugins"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "Editar CMS Plugin"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "Agregar CMS Plugin"
 

--- a/djangocms_text/locale/et/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/et/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Estonian (https://www.transifex.com/divio/teams/58664/et/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/eu/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/eu/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Basque (https://www.transifex.com/divio/teams/58664/eu/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/fa/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/fa/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Persian (https://www.transifex.com/divio/teams/58664/fa/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/fi/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/fi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/divio/teams/58664/fi/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/fr/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/fr/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2024\n"
 "Language-Team: French (https://app.transifex.com/divio/teams/58664/fr/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS Plugins"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "Modifier le plugin CMS"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "Ajouter un plugin CMS"
 

--- a/djangocms_text/locale/gl/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/gl/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Galician (https://www.transifex.com/divio/teams/58664/gl/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/he/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/he/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Hebrew (https://www.transifex.com/divio/teams/58664/he/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/hi/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/hi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Hindi (https://www.transifex.com/divio/teams/58664/hi/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/hr/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/hr/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Croatian (https://www.transifex.com/divio/teams/58664/hr/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/hu/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/hu/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Hungarian (https://www.transifex.com/divio/teams/58664/hu/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/is/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/is/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Icelandic (https://www.transifex.com/divio/teams/58664/is/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/it/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/it/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Italian (https://www.transifex.com/divio/teams/58664/it/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/ja/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/ja/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Japanese (https://www.transifex.com/divio/teams/58664/ja/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/lt/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/lt/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2024\n"
 "Language-Team: Lithuanian (https://app.transifex.com/divio/teams/58664/lt/)\n"
@@ -152,78 +152,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "TVS įskiepiai"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "Redaguotis TVS įskiepį"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "Pridėti TVS įskiepį"
 

--- a/djangocms_text/locale/nl/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/nl/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Fabian Braun <fsbraun@gmx.de>, 2024\n"
 "Language-Team: Dutch (https://app.transifex.com/divio/teams/58664/nl/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS-plug-ins"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "CMS-plug-in bewerken"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "CMS-plug-in toevoegen"
 

--- a/djangocms_text/locale/no/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/no/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Norwegian (https://www.transifex.com/divio/teams/58664/no/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/pl/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/pl/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Polish (https://www.transifex.com/divio/teams/58664/pl/)\n"
@@ -152,78 +152,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/pt/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/pt/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Portuguese (https://www.transifex.com/divio/teams/58664/pt/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/ro/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/ro/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Romanian (https://www.transifex.com/divio/teams/58664/ro/)\n"
@@ -151,78 +151,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/ru/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/ru/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Russian (https://www.transifex.com/divio/teams/58664/ru/)\n"
@@ -152,78 +152,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/sv/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/divio/teams/58664/sv/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/tr/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/tr/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Turkish (https://www.transifex.com/divio/teams/58664/tr/)\n"
@@ -150,78 +150,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/uk/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/uk/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2019-01-23 16:28+0000\n"
 "Last-Translator: Angelo Dini <angelo.dini@divio.ch>, 2019\n"
 "Language-Team: Ukrainian (https://www.transifex.com/divio/teams/58664/uk/)\n"
@@ -153,78 +153,110 @@ msgid "Table"
 msgstr ""
 
 #: editors.py:213
-msgid "Code"
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
 msgstr ""
 
 #: editors.py:219
-msgid "Small"
+msgid "Add column before"
 msgstr ""
 
 #: editors.py:222
-msgid "Keyboard input"
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
 msgstr ""
 
 #: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
+msgid "Code"
+msgstr ""
+
+#: editors.py:243
+msgid "Small"
+msgstr ""
+
+#: editors.py:246
+msgid "Keyboard input"
+msgstr ""
+
+#: editors.py:252
 msgid "Code block"
 msgstr ""
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr ""
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr ""
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr ""
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr ""
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr ""
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr ""
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr ""
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr ""
 
-#: editors.py:280
+#: editors.py:304
 msgid "Block format"
 msgstr ""
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr ""
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr ""
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr ""
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr ""
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr ""
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr ""
 

--- a/djangocms_text/locale/zh_CN/LC_MESSAGES/django.po
+++ b/djangocms_text/locale/zh_CN/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 01:08+0100\n"
+"POT-Creation-Date: 2024-12-22 23:13+0100\n"
 "PO-Revision-Date: 2024-02-15 10:49+0000\n"
 "Last-Translator: Scott Jiang, 2024\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/divio/teams/58664/"
@@ -153,80 +153,112 @@ msgid "Table"
 msgstr "表格"
 
 #: editors.py:213
+msgid "Add row before"
+msgstr ""
+
+#: editors.py:216
+msgid "Add row after"
+msgstr ""
+
+#: editors.py:219
+msgid "Add column before"
+msgstr ""
+
+#: editors.py:222
+msgid "Add column after"
+msgstr ""
+
+#: editors.py:225
+msgid "Delete row"
+msgstr ""
+
+#: editors.py:228
+msgid "Delete column"
+msgstr ""
+
+#: editors.py:231
+msgid "Delete table"
+msgstr ""
+
+#: editors.py:234
+msgid "Merge or split cells"
+msgstr ""
+
+#: editors.py:237
 msgid "Code"
 msgstr "代码"
 
-#: editors.py:219
+#: editors.py:243
 msgid "Small"
 msgstr "小的"
 
-#: editors.py:222
+#: editors.py:246
 msgid "Keyboard input"
 msgstr "键盘输入"
 
-#: editors.py:228
+#: editors.py:252
 msgid "Code block"
 msgstr "代码引用区"
 
-#: editors.py:235
+#: editors.py:259
 msgid "Heading 1"
 msgstr "标题 1 格式"
 
-#: editors.py:241
+#: editors.py:265
 msgid "Heading 2"
 msgstr "标题 2 格式"
 
-#: editors.py:247
+#: editors.py:271
 msgid "Heading 3"
 msgstr "标题 3 格式"
 
-#: editors.py:253
+#: editors.py:277
 msgid "Heading 4"
 msgstr "标题 4 格式"
 
-#: editors.py:259
+#: editors.py:283
 msgid "Heading 5"
 msgstr "标题 5 格式"
 
-#: editors.py:265
+#: editors.py:289
 msgid "Heading 6"
 msgstr "标题 6 格式"
 
-#: editors.py:271
+#: editors.py:295
 msgid "Paragraph"
 msgstr "段落"
 
-#: editors.py:277
+#: editors.py:301
 msgid "Anchor"
 msgstr "基点"
 
-#: editors.py:280
+#: editors.py:304
 #, fuzzy
 #| msgid "Blockquote"
 msgid "Block format"
 msgstr "引用区"
 
-#: editors.py:284
+#: editors.py:308
 msgid "Styles"
 msgstr "样式"
 
-#: editors.py:288
+#: editors.py:312
 msgid "Font"
 msgstr "字体"
 
-#: editors.py:291
+#: editors.py:315
 msgid "Font size"
 msgstr "字体大小"
 
-#: editors.py:294 editors.py:295 widgets.py:240 widgets.py:243
+#: editors.py:318 editors.py:319 widgets.py:240 widgets.py:243
 msgid "CMS Plugins"
 msgstr "CMS 的插件组"
 
-#: editors.py:296 widgets.py:242
+#: editors.py:320 widgets.py:242
 msgid "Edit CMS Plugin"
 msgstr "编辑 CMS 插件"
 
-#: editors.py:297 widgets.py:241
+#: editors.py:321 widgets.py:241
 msgid "Add CMS Plugin"
 msgstr "添加 CMS 插件"
 

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -67,6 +67,11 @@
                 box-shadow: 0 0 2px Highlight;
             }
         }
+        &.ProseMirror-focused {
+            td, th {
+                outline: Highlight solid 0.5px;
+            }
+        }
         & cms-plugin {
             pointer-events: auto;
             a {

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -129,33 +129,48 @@
             inset-inline-start: 0;
         }
     }
-    div.tt-create-table {
-        display: block;
-        position: relative;
-        width: calc(12px * 10);
-        height: calc(12px * 10 + 1rem);
-        button {
-            position: absolute;
-            top: 0;
-            inset-inline-start: 0;
-            padding: 4px !important; /* needed for djangocms-admin-style */
-            margin: 0px 2px !important;
-            border: 1px solid var(--dca-gray-lighter, var(--hairline-color)) !important;
-            margin-inline-start: var(--mx)  !important;
-            margin-top: var(--my) !important;
-            &:hover {
-                background-color: Highlight;
+    .tt-table {
+        &:has(> button:not([disabled])) {
+            --all-disabled: none;
+            --not-all-disabled: inline-flex;
+        }
+        > button {
+            display: var(--not-all-disabled, none);
+        }
+        > .separator {
+            display: var(--not-all-disabled, none);
+        }
+        div.tt-create-table {
+            &[disabled] {
+                display: none;
             }
-            &:hover::after {
+            display: var(--all-disabled, block);
+            position: relative;
+            width: calc(12px * 10);
+            height: calc(12px * 10 + 1rem);
+            button {
                 position: absolute;
-                top: calc(124px - var(--my));
-                inset-inline-start: calc(-1 * var(--mx));
-                text-align: center;
-                height: 2rem;
-                width: calc(12px * 10);
-                content: attr(title);
-                font-size: 0.7rem;
-                color: var(--dca-gray);
+                top: 0;
+                inset-inline-start: 0;
+                padding: 4px !important; /* needed for djangocms-admin-style */
+                margin: 0px 2px !important;
+                border: 1px solid var(--dca-gray-lighter, var(--hairline-color)) !important;
+                margin-inline-start: var(--mx)  !important;
+                margin-top: var(--my) !important;
+                &:hover {
+                    background-color: Highlight;
+                }
+                &:hover::after {
+                    position: absolute;
+                    top: calc(124px - var(--my));
+                    inset-inline-start: calc(-1 * var(--mx));
+                    text-align: center;
+                    height: 2rem;
+                    width: calc(12px * 10);
+                    content: attr(title);
+                    font-size: 0.7rem;
+                    color: var(--dca-gray);
+                }
             }
         }
     }

--- a/private/js/ckeditor4_plugins/cmsplugins/plugin.js
+++ b/private/js/ckeditor4_plugins/cmsplugins/plugin.js
@@ -109,7 +109,6 @@ import CmsDialog from "../../cms.dialog";
 
                 // this is called when creating the dropdown list
                 onBlock: function (panel, block) {
-					console.log("onBlock", editor.plugins);
                     block.element.setHtml(editor.plugins.CMSPlugins.setupDropdown(editor));
 
                     var anchors = $(block.element.$).find('.cke_panel_listItem a');

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -362,7 +362,6 @@ class CMSTipTapPlugin {
             // They need to refocus the editor to avoid a save
             const id = editor.options.el.id;
             const cms_dialog = document.querySelector(`#cms-top .cms-dialog[data-editor="${id}"]`);
-            console.log(cms_dialog, cms_dialog?.open);
             if(!editor.options.el.contains(document.activeElement) && !cms_dialog) {
                 // hide the toolbar
                 editor.options.element.querySelectorAll('[role="menubar"], [role="button"]')

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -360,7 +360,7 @@ class CMSTipTapPlugin {
         setTimeout(() => {
             // Allow toolbar and other editor widgets to process the click first
             // They need to refocus the editor to avoid a save
-            const id = editor.options.el.id;
+            const {id} = editor.options.el;
             const cms_dialog = document.querySelector(`#cms-top .cms-dialog[data-editor="${id}"]`);
             if(!editor.options.el.contains(document.activeElement) && !cms_dialog) {
                 // hide the toolbar

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -1,12 +1,14 @@
-/* eslint-env es6 */
-/* jshint esversion: 6 */
+/* eslint-env es11 */
+/* jshint esversion: 11 */
 /* global document, window, console */
 
 import {Editor} from '@tiptap/core';
+import {StarterKit} from "@tiptap/starter-kit";
 import Underline from '@tiptap/extension-underline';
 import CharacterCount from '@tiptap/extension-character-count';
-import Image from '@tiptap/extension-image';
 import CmsDynLink from './tiptap_plugins/cms.dynlink';
+import {CmsPluginNode, CmsBlockPluginNode} from './tiptap_plugins/cms.plugin';
+import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import Subscript from '@tiptap/extension-subscript';
 import Superscript from '@tiptap/extension-superscript';
@@ -15,9 +17,7 @@ import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import TableRow from '@tiptap/extension-table-row';
 import {TextAlign, TextAlignOptions} from '@tiptap/extension-text-align';
-import {CmsPluginNode, CmsBlockPluginNode} from './tiptap_plugins/cms.plugin';
 import TiptapToolbar from "./tiptap_plugins/cms.tiptap.toolbar";
-import {StarterKit} from "@tiptap/starter-kit";
 
 import {InlineColors, Small, Var, Kbd, Samp} from "./tiptap_plugins/cms.styles";
 import CmsBalloonToolbar from "./tiptap_plugins/cms.balloon-toolbar";
@@ -360,7 +360,10 @@ class CMSTipTapPlugin {
         setTimeout(() => {
             // Allow toolbar and other editor widgets to process the click first
             // They need to refocus the editor to avoid a save
-            if(!editor.options.el.contains(document.activeElement)) {
+            const id = editor.options.el.id;
+            const cms_dialog = document.querySelector(`#cms-top .cms-dialog[data-editor="${id}"]`);
+            console.log(cms_dialog, cms_dialog?.open);
+            if(!editor.options.el.contains(document.activeElement) && !cms_dialog) {
                 // hide the toolbar
                 editor.options.element.querySelectorAll('[role="menubar"], [role="button"]')
                     .forEach((el) => el.classList.remove('show'));

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -44,7 +44,7 @@ class CMSTipTapPlugin {
                 Subscript,
                 Superscript,
                 Table.configure({
-                    resizable: false,
+                    resizable: true,
                     HTMLAttributes: {
                         class: 'table',
                     },

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -387,7 +387,10 @@ class CMSTipTapPlugin {
                 item = TiptapToolbar[item].insitu;
             } else if (item in TiptapToolbar && TiptapToolbar[item].items) {
                 // Create submenu
-                const repr = this._getRepresentation(item);
+                const repr = this._getRepresentation(item, filter);
+                if (!repr) {
+                    continue;
+                }
                 item = TiptapToolbar[item];
                 item.title = repr.title;
                 item.icon = repr.icon;
@@ -400,14 +403,14 @@ class CMSTipTapPlugin {
             } else if (item.constructor === Object) {
                 let dropdown;
 
-                if (typeof item.items === 'string') {
-                    dropdown = item.items;
+                if (typeof item.items === 'function') {
+                    dropdown = item.items(editor, (items) => this._populateToolbar(editor, items, filter));
                 } else {
                     dropdown = this._populateToolbar(editor, item.items, filter);
                     // Are there any items in the dropdown?
-                    if (dropdown.replaceAll(this.separator_markup, '').replaceAll(this.space_markup, '').length === 0) {
-                        continue;
-                    }
+                }
+                if (dropdown.replaceAll(this.separator_markup, '').replaceAll(this.space_markup, '').length === 0) {
+                    continue;
                 }
                 const title = item.title && item.icon ? `title='${item.title}' ` : '';
                 const icon = item.icon || item.title;

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -29,7 +29,6 @@ const _tableMenu = [
 ];
 
 function generateTableMenu(editor, builder) {
-    console.log(builder(_tableMenu));
     return generateButtonArray(10, 10) + builder(_tableMenu);
 }
 

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -12,9 +12,25 @@ function generateButtonArray(rows, cols) {
             buttons += `<button title="${i+1}x${j+1}" data-action="Table" style="--mx: ${i*12}px; --my: ${j*12+4}px;" data-rows="${j+1}" data-cols="${i+1}"></button>`;
         }
     }
-    buttons += '<div class="tt-selection"></div>'
     buttons += '</div>';
     return buttons;
+}
+
+const _tableMenu = [
+    'addColumnBefore',
+    'addColumnAfter',
+    'deleteColumn',
+    '|',
+    'addRowBefore',
+    'addRowAfter',
+    'deleteRow',
+    '|',
+    'mergeOrSplit',
+];
+
+function generateTableMenu(editor, builder) {
+    console.log(builder(_tableMenu));
+    return generateButtonArray(10, 10) + builder(_tableMenu);
 }
 
 
@@ -162,7 +178,7 @@ const TiptapToolbar = {
         enabled: (editor) => editor.can().unsetLink(),
         type: 'mark',
     },
-    TipTapTable: {
+    Table: {
         action: (editor, button) => {
             const rows = parseInt(button.dataset.rows);
             const cols = parseInt(button.dataset.cols);
@@ -170,7 +186,43 @@ const TiptapToolbar = {
         },
         enabled: (editor) => editor.can().insertTable({ rows: 3, cols: 3 }),
         type: 'mark',
-        items: generateButtonArray(10,10),
+        items: generateTableMenu,
+        class: 'tt-table',
+    },
+    addColumnBefore: {
+        action: (editor, button) => editor.chain().focus().addColumnBefore().run(),
+        enabled: (editor) => editor.can().addColumnBefore(),
+        type: 'mark',
+    },
+    addColumnAfter: {
+        action: (editor, button) => editor.chain().focus().addColumnAfter().run(),
+        enabled: (editor) => editor.can().addColumnAfter(),
+        type: 'mark',
+    },
+    deleteColumn: {
+        action: (editor, button) => editor.chain().focus().deleteColumn().run(),
+        enabled: (editor) => editor.can().deleteColumn(),
+        type: 'mark',
+    },
+    addRowBefore: {
+        action: (editor, button) => editor.chain().focus().addRowBefore().run(),
+        enabled: (editor) => editor.can().addRowBefore(),
+        type: 'mark',
+    },
+    addRowAfter: {
+        action: (editor, button) => editor.chain().focus().addRowAfter().run(),
+        enabled: (editor) => editor.can().addRowAfter(),
+        type: 'mark',
+    },
+    deleteRow: {
+        action: (editor, button) => editor.chain().focus().deleteRow().run(),
+        enabled: (editor) => editor.can().deleteRow(),
+        type: 'mark',
+    },
+    mergeOrSplit: {
+        action: (editor, button) => editor.chain().focus().mergeOrSplit().run(),
+        enabled: (editor) => editor.can().mergeOrSplit(),
+        type: 'mark',
     },
     Code: {
         action: (editor) => editor.chain().focus().toggleCode().run(),


### PR DESCRIPTION
This PR adds table support for the TipTap RTE:
* Add tables from the editor toolbar (1x1 up to 10x10)
* Add/delete rows and columns from the toolbar
* Merge/split cells
* Resize columns

Fixes #21 

## Summary by Sourcery

Add support for table manipulation in the TipTap editor.

New Features:
- Enable resizing of tables in the editor.

Tests:
- Update tests to cover the new table features.

## Summary by Sourcery

Add support for creating and manipulating tables in the TipTap editor.

New Features:
- Add table support to the TipTap editor, including creating tables from the toolbar (1x1 up to 10x10), adding and deleting rows and columns, merging and splitting cells, and resizing columns.

Tests:
- Update existing tests to cover new table features.