### PR TITLE
fix: Proper registration of third-party RTE (CKEditor4 or 5, or other)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.5.1 (30-12-2024)
+==================
+
+* fix: Proper registration of third-party RTE (CKEditor4 or 5, or other) by @fsbraun in https://github.com/django-cms/djangocms-text/pull/47
+
 0.5.0 (28-12-2024)
 ==================
 

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/djangocms_text/cms_plugins.py
+++ b/djangocms_text/cms_plugins.py
@@ -49,7 +49,7 @@ from cms.utils.urlutils import admin_reverse
 from . import settings
 from .forms import ActionTokenValidationForm, RenderPluginForm, TextForm
 from .html import render_dynamic_attributes
-from .models import Text
+from .models import Text, _MAX_RTE_LENGTH
 from .utils import (
     OBJ_ADMIN_WITH_CONTENT_RE_PATTERN,
     _plugin_tags_to_html,
@@ -712,7 +712,7 @@ class TextPlugin(CMSPluginBase):
                 # subclassing cms_plugin_instance (one to one relation)
                 value = getattr(self.cms_plugin_instance, field.name)
                 setattr(obj, field.name, value)
-        obj.rte = rte_config.name
+        obj.rte = rte_config.name[:_MAX_RTE_LENGTH]
         super().save_model(request, obj, form, change)
         # This must come after calling save
         # If `clean_plugins()` deletes child plugins, django-treebeard will call

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -485,14 +485,15 @@ def get_editor_config(editor: Optional[str] = None) -> RTEConfig:
     """
 
     config = editor or getattr(settings, "TEXT_EDITOR", "tiptap")
-    if "." in config and config not in configuration:
+    config_name = config.rsplit(".", 1)[-1]
+    if config_name not in configuration:
         # Load the configuration from the module
         module = __import__(config.rsplit(".", 1)[0], fromlist=[""])
-        rte_config_instance = getattr(module, config.rsplit(".", 1)[-1])
+        rte_config_instance = getattr(module, config_name)
         # Cache editor configuration
-        rte_config_instance.name = config
+        rte_config_instance.name = config_name
         register(rte_config_instance)
-    return configuration[config]
+    return configuration[config_name]
 
 
 def get_editor_base_config(editor: Optional[str] = None) -> dict:

--- a/djangocms_text/models.py
+++ b/djangocms_text/models.py
@@ -7,6 +7,10 @@ from django.utils.html import strip_tags
 from django.utils.text import Truncator
 from django.utils.translation import gettext_lazy as _
 
+
+_MAX_RTE_LENGTH = 16
+
+
 if apps.is_installed("cms"):
     from cms.models import CMSPlugin
 
@@ -52,7 +56,7 @@ if apps.is_installed("cms"):
         rte = models.CharField(
             default="",
             blank=True,
-            max_length=16,
+            max_length=_MAX_RTE_LENGTH,
             help_text="The rich text editor used to create this text. JSON formats vary between editors.",
         )
 

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -12,6 +12,7 @@
         max-width: 100%; /* for djangocms-admin-style */
 
         .ProseMirror {
+            height: 100%;
             overflow-y: scroll;
             padding: 0 0.5rem;
 

--- a/tests/integration/test_ckeditor4.py
+++ b/tests/integration/test_ckeditor4.py
@@ -39,8 +39,6 @@ def test_editor_loads(live_server, page, text_plugin, superuser, use_ckeditor4):
     assert not console_errors, f"Console errors found: {console_errors}"
 
 
-
-
 @pytest.mark.django_db
 @pytest.mark.skipif(not DJANGO_CMS4, reason="Integration tests only work on Django CMS 4")
 def test_editor_saves(live_server, page, text_plugin, superuser, use_ckeditor4):

--- a/tests/integration/test_ckeditor4.py
+++ b/tests/integration/test_ckeditor4.py
@@ -53,5 +53,5 @@ def test_editor_saves(live_server, page, text_plugin, superuser, use_ckeditor4):
     save_button = page.locator('input[type="submit"]')
     save_button.click()
 
-    messagelist = page.locator(".messagelist")
+    messagelist = page.locator("div.messagelist")
     assert '<div class="success"></div>' in messagelist.inner_html().strip()

--- a/tests/integration/test_ckeditor4.py
+++ b/tests/integration/test_ckeditor4.py
@@ -37,3 +37,21 @@ def test_editor_loads(live_server, page, text_plugin, superuser, use_ckeditor4):
     expect(page.locator(".cke_button.cke_button__bold")).to_be_visible()  # a button in the menu bar
 
     assert not console_errors, f"Console errors found: {console_errors}"
+
+
+
+
+@pytest.mark.django_db
+@pytest.mark.skipif(not DJANGO_CMS4, reason="Integration tests only work on Django CMS 4")
+def test_editor_saves(live_server, page, text_plugin, superuser, use_ckeditor4):
+    """Test that tiptap editor loads and initializes properly"""
+    # Navigate to the text plugin add view
+    login(live_server, page, superuser)
+
+    page.goto(f"{live_server.url}{admin_reverse('cms_placeholder_edit_plugin', args=(text_plugin.pk,))}")
+
+    save_button = page.locator('input[type="submit"]')
+    save_button.click()
+
+    messagelist = page.locator(".messagelist")
+    assert '<div class="success"></div>' in messagelist.inner_html().strip()


### PR DESCRIPTION
Fixes #46

## Summary by Sourcery

Fix the registration of third-party rich text editors by correcting the configuration loading logic and caching. Enhance code maintainability by introducing a constant for maximum RTE length and ensure RTE names are truncated appropriately. Add an integration test to verify editor save functionality in Django CMS 4.

Bug Fixes:
- Fix the registration process for third-party rich text editors by ensuring proper configuration loading and caching.

Enhancements:
- Introduce a constant for maximum RTE length to improve code maintainability.
- Ensure the RTE name is truncated to the maximum allowed length when saving models.

Tests:
- Add a new integration test to verify that the editor saves content correctly in Django CMS 4.