### PR TITLE
feat: Add text color from list of options

### DIFF
--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -70,6 +70,15 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
         + '  <path d="m4.266 12.496.96-2.853H8.76l.96 2.853H11L7.62 3H6.38L3 12.496zm2.748-8.063 1.419 4.23h-2.88l1.426-4.23zm5.132-1.797v-.075c0-.332.234-.618.619-.618.354 0 .618.256.618.58 0 .362-.271.649-.52.898l-1.788 1.832V6h3.59v-.958h-1.923v-.045l.973-1.04c.415-.438.867-.845.867-1.547 0-.8-.701-1.41-1.787-1.41C11.565 1 11 1.8 11 2.576v.06z"/>\n'
         + "</svg>",
     },
+    "TextColor": {
+        "title": _("Text color"),
+    },
+    "InlineQuote": {
+        "title": _("Inline quote"),
+    },
+    "Highlight": {
+        "title": _("Mark"),
+    },
     "RemoveFormat": {
         "title": _("Remove formatting"),
         "icon": '<svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16" '
@@ -149,17 +158,6 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
     "Link": {
         "title": _("Link"),
         "form": [
-            # {
-            #     "type": "link",
-            #     "url": '#',
-            #     "label": '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" '
-            #              'class="bi bi-box-arrow-up-left" viewBox="0 0 16 16">'
-            #              '<path fill-rule="evenodd" d="M7.364 3.5a.5.5 0 0 1 .5-.5H14.5A1.5 1.5 0 0 1 16 4.5v10a1.5 '
-            #              '1.5 0 0 1-1.5 1.5h-10A1.5 1.5 0 0 1 3 14.5V7.864a.5.5 0 1 1 1 0V14.5a.5.5 0 0 0 .5.5h10a.5.5 '
-            #              '0 0 0 .5-.5v-10a.5.5 0 0 0-.5-.5H7.864a.5.5 0 0 1-.5-.5"/><path fill-rule="evenodd" '
-            #              'd="M0 .5A.5.5 0 0 1 .5 0h5a.5.5 0 0 1 0 1H1.707l8.147 8.146a.5.5 0 0 1-.708.708L1 '
-            #              '1.707V5.5a.5.5 0 0 1-1 0z"/></svg>',
-            # },
             {
                 "name": "href_select",
                 "type": "hidden",
@@ -316,12 +314,10 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
         "title": _("Anchor"),
     },
     "Format": {
-        "title": _("Block format"),
-        "class": "vertical",
+        "title": _("Format"),
     },
     "Styles": {
         "title": _("Styles"),
-        "menu": [],
     },
     "Font": {
         "title": _("Font"),
@@ -371,13 +367,14 @@ DEFAULT_TOOLBAR_CMS = [
     ["Undo", "Redo"],
     ["CMSPlugins", "cmswidget", "-", "ShowBlocks"],
     ["Format", "Styles"],
-    ["TextColor", "BGColor", "-", "PasteText", "PasteFromWord"],
+    ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [
         "Bold",
         "Italic",
         "Underline",
         "-",
+        "InlineQuote",
         "Code",
         "-",
         "Subscript",
@@ -396,13 +393,14 @@ DEFAULT_TOOLBAR_HTMLField = [
     ["Undo", "Redo"],
     ["ShowBlocks"],
     ["Format", "Styles"],
-    ["TextColor", "BGColor", "-", "PasteText", "PasteFromWord"],
+    ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [
         "Bold",
         "Italic",
         "Underline",
         "-",
+        "InlineQuote",
         "Code",
         "-",
         "Subscript",
@@ -512,7 +510,7 @@ register(
         name="tiptap",
         config="TIPTAP",
         js=("djangocms_text/bundles/bundle.tiptap.min.js",),
-        css={"all": ("djangocms_text/css/bundle.tiptap.min.css",)},
+        css={"all": ("djangocms_text/css/bundle.tiptap.min.css", "djangocms_text/css/tiptap.admin.css")},
         inline_editing=True,
         child_plugin_support=True,
     )

--- a/djangocms_text/static/djangocms_text/css/tiptap.admin.css
+++ b/djangocms_text/static/djangocms_text/css/tiptap.admin.css
@@ -1,0 +1,77 @@
+.cms-admin {
+    .text-secondary {
+        color: gray;
+    }
+
+    .text-primary {
+        color: mediumblue;
+    }
+
+    .text-success {
+        color: green;
+    }
+
+    .text-danger {
+        color: red;
+    }
+
+    .text-warning {
+        color: orange;
+    }
+
+    .text-info {
+        color: deepskyblue;
+    }
+
+    .text-light {
+        color: lightgrey;
+    }
+
+    .text-dark {
+        color: black;
+    }
+
+    .text-body {
+        color: var(--body-fg);
+    }
+
+    .text-muted {
+        color: dimgrey;
+    }
+
+    .text-secondary {
+        color: gray;
+    }
+
+    .bg-primary {
+        background-color: mediumblue;
+    }
+
+    .bg-success {
+        background-color: green;
+    }
+
+    .bg-danger {
+        background-color: red;
+    }
+
+    .bg-warning {
+        background-color: orange;
+    }
+
+    .bg-info {
+        background-color: deepskyblue;
+    }
+
+    .bg-light {
+        background-color: lightgrey;
+    }
+
+    .bg-dark {
+        background-color: black;
+    }
+
+    .bg-body {
+        background-color: var(--body-bg);
+    }
+}

--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -10,6 +10,6 @@ class TextEditorWidget(NewTextEditorWidget):  # pragma: no cover
             "djangocms_text_ckeditor.widgets.TextEditorWidget is deprecated. "
             "Use djangocms_text.widgets.TextEditorWidget instead.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         super().__init__(*args, **kwargs)

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -136,7 +136,7 @@
         &:active, &.active {
             background: var(--dca-gray-lighter, var(--selected-bg))  !important;
         }
-        &:hover:not(:disabled),&.show {
+        &:hover:not(:disabled):not([data-action="TextColor"]),&.show {
             color: var(--dca-white, var(--button-fg)) !important;
             background: var(--dca-primary, var(--button-bg))  !important;
         }
@@ -151,8 +151,27 @@
             &:after{
                 content: "▼";
                 margin-block-start: 3px;
-                margin-inline-start: 6px;
+                margin-inline-start: 2px;
+                margin-inline-end: 4px;
                 font-size: 0.8rem;
+            }
+            span {
+                margin-top: 0.1rem;
+            }
+            &:has([data-action="TextColor"]) > svg {
+                border-bottom: 2px solid currentColor;
+            }
+            button[data-action="TextColor"] {
+                background: currentColor;
+                border: 1px solid var(--dca-gray-lighter, var(--hairline-color)) !important;
+                margin-inline-end: 0.5rem;
+                width: 1.6rem !important;
+                height: 1.2rem;
+                &:hover, &.active {
+                    background-color: currentColor !important;
+                    outline: 3px solid var(--dca-primary, var(--primary));
+                };
+
             }
         }
         svg {
@@ -306,6 +325,4 @@
             }
         }
     }
-
 }
-

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -19,7 +19,7 @@ import TableRow from '@tiptap/extension-table-row';
 import {TextAlign, TextAlignOptions} from '@tiptap/extension-text-align';
 import TiptapToolbar from "./tiptap_plugins/cms.tiptap.toolbar";
 
-import {InlineColors, Small, Var, Kbd, Samp} from "./tiptap_plugins/cms.styles";
+import {TextColor, Small, Var, Kbd, Samp, Highlight, InlineQuote} from "./tiptap_plugins/cms.styles";
 import CmsFormExtension from "./tiptap_plugins/cms.formextension";
 import CmsToolbarPlugin from "./tiptap_plugins/cms.toolbar";
 
@@ -35,7 +35,7 @@ class CMSTipTapPlugin {
                 Underline,
                 CharacterCount,
                 Image,
-                InlineColors,
+                TextColor,
                 Placeholder,
                 Subscript,
                 Superscript,
@@ -49,7 +49,7 @@ class CMSTipTapPlugin {
                 TableHeader,
                 TableCell,
                 CmsDynLink,
-                Small, Var, Kbd, Samp,
+                Small, Var, Kbd, Samp, Highlight, InlineQuote,
                 TextAlign.configure({
                     types: ['heading', 'paragraph'],
                 }),

--- a/private/js/tiptap_plugins/cms.dynlink.js
+++ b/private/js/tiptap_plugins/cms.dynlink.js
@@ -11,8 +11,15 @@ function DynLinkClickHandler(editor) {
     return new Plugin({
         props: {
             handleDOMEvents: {
-                click(view, event) {
-                    console.log(view);
+                click (view, event) {
+                    const target = event.target.closest('a[href]');
+                    if (target) {
+                        event.preventDefault();
+                        return true;
+                    }
+                    return false;
+                },
+                dblclick(view, event) {
                     const target = event.target.closest('a[href]');
                     if (target) {
                         event.preventDefault();

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -5,16 +5,18 @@
 
 import {Mark, mergeAttributes,} from '@tiptap/core';
 
-'use strict';
-
 
 const _markElement = {
     addOptions() {
+        'use strict';
+
         return {
             HTMLAttributes: {},
         };
     },
     parseHTML() {
+        'use strict';
+
         return [
             {
                 tag: this.name.toLowerCase()
@@ -24,6 +26,7 @@ const _markElement = {
     renderHTML({ HTMLAttributes }) {
         return [this.name.toLowerCase(), mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
     },
+
     addCommands() {
         'use strict';
         let commands = {};
@@ -61,65 +64,119 @@ const Samp = Mark.create({
     ..._markElement,
 });
 
+const InlineQuote = Mark.create({
+    name: 'Q',
+    ..._markElement,
+});
 
-const InlineColors = Mark.create({
-    name: 'inlinestyle',
+const Highlight = Mark.create({
+    name: 'Highlight',
+    parseHTML() {
+        'use strict';
+        return [{tag: 'mark'}];
+    },
+    renderHTML({ HTMLAttributes }) {
+        return ['mark', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+    },
+});
+
+const TextColor = Mark.create({
+    name: 'textcolor',
     addOptions() {
+        'use strict';
         return {
-            styles: {
-                primary: {"class": "text-primary"},
-                secondary: {"class": "text-secondary"},
-                success: {"class": "text-success"},
-                danger: {"class": "text-danger"},
-                warning: {"class": "text-warning"},
-                info: {"class": "text-info"},
-                light: {"class": "text-light"},
-                dark: {"class": "text-dark"},
-                body: {"class": "text-body"},
-                muted: {"class": "text-muted"},
+            textColors: {
+                'text-primary': {name: "Primary"},
+                'text-secondary': {name: "Secondary"},
+                'text-success': {name: "Success"},
+                'text-danger': {name: "Danger"},
+                'text-warning': {name: "Warning"},
+                'text-info': {name: "Info"},
+                'text-light': {name: "Light"},
+                'text-dark': {name: "Dark"},
+                'text-body': {name: "Body"},
+                'text-muted': {name: "Muted"},
             },
         };
     },
+
+    onCreate() {
+        'use strict';
+
+        if (this.editor.options.textColors) {
+            // Let editor options overwrite the default colors
+            this.options.textColors = this.editor.options.textColors;
+        }
+    },
+
     addAttributes() {
+        'use strict';
+
         return {
             class: {
                 default: null,
             },
+            style: {
+                default: null,
+            }
         };
     },
 
-    parseHTML: element => [
-        {
-            tag: 'style',
-            getAttrs: node => node.classList.filter((item) => item in this.options.styles)
-        },
-    ],
+    parseHTML() {
+        'use strict';
+
+        return [
+            {
+                tag: '*',
+                getAttrs: (node) => {
+                    for (const cls of Object.keys(this.options?.textColors || {})) {
+                        if (node.classList.contains(cls)) {
+                            return {class: cls};
+                        }
+                    }
+                    return false;
+                }
+            },
+            {
+                tag: '*',
+                getAttrs: node => {
+                    if (node.style.color) {
+                        return {style: node.style.color};
+                    }
+                    return false;
+                }
+            }
+        ];
+    },
+
     renderHTML: attributes => {
-        return ['span',  mergeAttributes({}, attributes.HTMLAttributes), 0]
+        'use strict';
+        return ['span',  mergeAttributes({}, attributes.HTMLAttributes), 0];
     },
 
     addCommands() {
+        'use strict';
         return {
-            setStyle: (style) => ({commands}) => {
-                if (!this.options.styles.hasOwnProperty(style)) {
+            setTextColor: (cls) => ({commands}) => {
+                if (!(cls in this.options.textColors)) {
                     return false;
                 }
-                return commands.setMark(this.name, this.options.styles[style] );
+                return commands.setMark(this.name, {"class": cls} );
             },
-            toggleStyle: (style) => ({commands}) => {
-                if (!this.options.styles.hasOwnProperty(style)) {
+            toggleTextColor: (cls) => ({commands}) => {
+                if (!(cls in this.options.textColors)) {
                     return false;
                 }
-                return commands.toggleMark(this.name, this.options.styles[style] );
+                return commands.toggleMark(this.name, {"class": cls} );
             },
-            unsetStyle: (style) => ({commands}) => {
-                if (!this.options.styles.hasOwnProperty(style)) {
+            unsetTextColor: (cls) => ({commands}) => {
+                if (!(cls in this.options.textColors)) {
                     return false;
                 }
-                return commands.unsetMark(this.name, this.options.styles[style] );
+                return commands.unsetMark(this.name, {"class": cls} );
             },
         };
     }
 });
 
-export {InlineColors, Small, Var, Kbd, Samp, InlineColors as default};
+export {TextColor, Small, Var, Kbd, Samp, Highlight, InlineQuote, TextColor as default};

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -164,6 +164,9 @@ const TextColor = Mark.create({
                 return commands.setMark(this.name, {"class": cls} );
             },
             toggleTextColor: (cls) => ({commands}) => {
+                if (!cls) {
+                    cls = Object.keys(this.options.textColors)[0];
+                }
                 if (!(cls in this.options.textColors)) {
                     return false;
                 }

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -99,9 +99,9 @@ const TiptapToolbar = {
                 // If the user is currently changing a text color, update the whole colored section
                 editor.commands.extendMarkRange('textcolor');
             }
-            editor.commands.toggleTextColor(button.dataset?.class);
+            editor.commands.toggleTextColor(button?.dataset?.class || 'text-primary');
         },
-        enabled: (editor, button) => editor.can().toggleTextColor(button.dataset?.class),
+        enabled: (editor) => editor.can().toggleTextColor(),
         active: (editor, button) => editor.isActive('textcolor', {class: button.dataset?.class}),
         items: generateColorMenu,
         icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-fonts" viewBox="0 0 16 16"><path d="M12.258 3h-8.51l-.083 2.46h.479c.26-1.544.758-1.783 2.693-1.845l.424-.013v7.827c0 .663-.144.82-1.3.923v.52h4.082v-.52c-1.162-.103-1.306-.26-1.306-.923V3.602l.431.013c1.934.062 2.434.301 2.693 1.846h.479z"/></svg>',

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -104,9 +104,8 @@ function _createBlockToolbar(editor, blockToolbar) {
         const start = parseInt(editor.options.blockToolbar.dataset.start);
         const end = parseInt(editor.options.blockToolbar.dataset.end);
         const depth = parseInt(editor.options.blockToolbar.dataset.depth);
-        // const {resolvedPos, depth} = _getResolvedPos(editor.view.state);
+
         if (depth >= 0 && start >= 0 && end >= 0) {
-            // const block = resolvedPos.start(depth);
             const {state, dispatch} = editor.view;
             const textSelection = TextSelection.create(state.doc, start, end-1);
             const domNode = editor.view.domAtPos(start).node;
@@ -338,7 +337,7 @@ function _createDropdown(editor, item, filter) {
         return '';
     }
     const title = item.title && item.icon ? `title='${item.title}' ` : '';
-    const icon = item.icon || item.title;
+    const icon = item.icon || `<span>${item.title}</span>`;
     return `<span ${title}class="dropdown" role="button">${icon}<div title class="dropdown-content ${item.class || ''}">${dropdown}</div></span>`;
 }
 
@@ -351,15 +350,14 @@ function _populateGroup(editor, array, filter) {
 
 function _populateToolbar(editor, array, filter) {
     'use strict';
-
     let html = array.map(item => {
-        if (item in TiptapToolbar && TiptapToolbar[item].insitu) {
+        if (item in TiptapToolbar && TiptapToolbar[item].insitu && filter === 'block') {
             return _populateGroup(editor, TiptapToolbar[item].insitu, filter);
         }
         if (Array.isArray(item)) {
             return _populateGroup(editor, item, filter);
         }
-        if (item in TiptapToolbar && TiptapToolbar[item].items) {
+        if (item in TiptapToolbar && (TiptapToolbar[item].items || TiptapToolbar[item].insitu)) {
             // Create submenu
             const repr = window.cms_editor_plugin._getRepresentation(item, filter);
             if (!repr) {
@@ -368,6 +366,9 @@ function _populateToolbar(editor, array, filter) {
             item = TiptapToolbar[item];
             item.title = repr.title;
             item.icon = repr.icon;
+            if (!item.items) {
+                item.items = item.insitu;
+            }
         }
         if (item.constructor === Object) {
             return _createDropdown(editor, item, filter);
@@ -416,8 +417,9 @@ function _createToolbarButton(editor, itemName, filter) {
                 </div>
             </form>`;
         }
+        const content = repr.icon || `<span>${repr.title}</span>`;
         return `<button data-action="${repr.dataaction}" ${cmsplugin}${title}${position}class="${classes}" role="button">
-                        ${repr.icon || repr.title}${form}
+                        ${content}${form}
                     </button>`;
     }
     return '';
@@ -442,7 +444,7 @@ function _updateToolbar(editor, toolbar) {
               try {
                   button.disabled = !toolbarItem?.enabled(editor, button);
                   try {
-                      if (toolbarItem?.active(editor, button)) {
+                      if (toolbarItem.active && toolbarItem.active(editor, button)) {
                           button.classList.add('active');
                       } else {
                           button.classList.remove('active');
@@ -451,6 +453,7 @@ function _updateToolbar(editor, toolbar) {
                           populateForm(button, TiptapToolbar[action].attributes(editor), toolbarItem.form);
                       }
                   } catch (e) {
+                      console.log(e);
                   }
               } catch (e) {
                   console.warn(e);

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -453,7 +453,6 @@ function _updateToolbar(editor, toolbar) {
                           populateForm(button, TiptapToolbar[action].attributes(editor), toolbarItem.form);
                       }
                   } catch (e) {
-                      console.log(e);
                   }
               } catch (e) {
                   console.warn(e);

--- a/tests/integration/test_text_editor.py
+++ b/tests/integration/test_text_editor.py
@@ -30,5 +30,6 @@ def test_editor_loads(live_server, page, text_plugin, superuser):
     expect(page.locator('div[role="menubar"]')).to_be_visible()  # its menu bar
     expect(page.locator('button[title="Bold"]')).to_be_visible()  # a button in the menu bar
 
-    assert tiptap.inner_text() == "Test content"
+    content = tiptap.locator("> :not(div)")  # only look at content
+    assert content.inner_text() == "Test content"
     assert not console_errors, f"Console errors found: {console_errors}"


### PR DESCRIPTION
* Allows user to color text from a predefined set of classes (like `text-primary`) 
* Allows user to higlight text (`<mark>` tag)

## Summary by Sourcery

Add text color and highlight features to the rich text editor.

New Features:
- Allow users to color text using predefined classes (e.g., "text-primary").
- Allow users to highlight text using the <mark> tag.

Tests:
- Update editor tests to cover the new text color and highlight features.