### PR TITLE
feat: allows an `admin_css: tuple` in `RTEConfig` for a list of CSS files only to be loaded into the admin for the editor

### DIFF
--- a/djangocms_text/cms_plugins.py
+++ b/djangocms_text/cms_plugins.py
@@ -249,6 +249,7 @@ class TextPlugin(CMSPluginBase):
                 action_token=action_token,
                 revert_on_cancel=settings.TEXT_CHILDREN_ENABLED and rte_config.child_plugin_support,
                 body_css_classes=self._get_body_css_classes_from_parent_plugins(plugin),
+                add_admin_css=True,
             )
         else:
             widget = TextEditorWidget(

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -478,7 +478,7 @@ def register(editor: RTEConfig):
     configuration[editor.name] = editor
 
 
-def get_editor_config(editor: Optional[str] = None) -> RTEConfig:
+def get_editor_config(editor: str | None = None) -> RTEConfig:
     """
     Returns the editor configuration.
 
@@ -498,7 +498,7 @@ def get_editor_config(editor: Optional[str] = None) -> RTEConfig:
     return configuration[config_name]
 
 
-def get_editor_base_config(editor: Optional[str] = None) -> dict:
+def get_editor_base_config(editor: str | None = None) -> dict:
     """
     Returns the base configuration for the editor.
 

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 from collections.abc import Iterable
 
@@ -436,9 +438,9 @@ class RTEConfig:
         self,
         name: str,
         config: str,
-        js: Iterable[str] = None,
-        css: dict = None,
-        admin_css: dict = None,
+        js: Iterable[str] | None = None,
+        css: dict | None = None,
+        admin_css: dict | None = None,
         inline_editing: bool = False,
         child_plugin_support: bool = False,
     ):

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
 from collections.abc import Iterable
 
 from django.conf import settings

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -512,8 +512,8 @@ register(
         name="tiptap",
         config="TIPTAP",
         js=("djangocms_text/bundles/bundle.tiptap.min.js",),
-        css={"all": ("djangocms_text/css/bundle.tiptap.min.css", )},
-        admin_css = ("djangocms_text/css/tiptap.admin.css",),
+        css={"all": ("djangocms_text/css/bundle.tiptap.min.css",)},
+        admin_css=("djangocms_text/css/tiptap.admin.css",),
         inline_editing=True,
         child_plugin_support=True,
     )

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -438,6 +438,7 @@ class RTEConfig:
         config: str,
         js: Iterable[str] = None,
         css: dict = None,
+        admin_css: dict = None,
         inline_editing: bool = False,
         child_plugin_support: bool = False,
     ):
@@ -446,6 +447,7 @@ class RTEConfig:
         self.config = config
         self.js = js or []
         self.css = css or {}
+        self.admin_css = admin_css or ()
         self.inline_editing = inline_editing
         self.child_plugin_support = child_plugin_support
 
@@ -510,7 +512,8 @@ register(
         name="tiptap",
         config="TIPTAP",
         js=("djangocms_text/bundles/bundle.tiptap.min.js",),
-        css={"all": ("djangocms_text/css/bundle.tiptap.min.css", "djangocms_text/css/tiptap.admin.css")},
+        css={"all": ("djangocms_text/css/bundle.tiptap.min.css", )},
+        admin_css = ("djangocms_text/css/tiptap.admin.css",),
         inline_editing=True,
         child_plugin_support=True,
     )

--- a/djangocms_text/fields.py
+++ b/djangocms_text/fields.py
@@ -65,7 +65,7 @@ class HTMLField(models.TextField):
         # override the admin widget
         if defaults["widget"] == admin_widgets.AdminTextareaWidget:
             # In the admin the URL endpoint is available
-            defaults["widget"] = TextEditorWidget(configuration=self.configuration)
+            defaults["widget"] = TextEditorWidget(configuration=self.configuration, add_admin_css=True)
         return super().formfield(**defaults)
 
     def clean(self, value, model_instance):

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -88,13 +88,16 @@ class TextEditorWidget(forms.Textarea):
     @property
     def media(self):
         rte_config = get_editor_config()
+        rte_css = rte_config.css.get("all", ())
+        if self.add_admin_css:
+            rte_css += rte_config.admin_css
         return forms.Media(
             css={
                 **rte_config.css,
                 "all": (
                     "djangocms_text/css/cms.text.css",
                     "djangocms_text/css/cms.normalize.css",
-                    *rte_config.css.get("all", ()),
+                    *rte_css,
                 ),
             },
             js=(
@@ -120,6 +123,7 @@ class TextEditorWidget(forms.Textarea):
         action_token: str = None,
         revert_on_cancel: bool = False,
         body_css_classes: str = "",
+        add_admin_css: bool = False,
     ):
         """
         Create a widget for editing text + plugins.
@@ -156,6 +160,7 @@ class TextEditorWidget(forms.Textarea):
         self.action_token = action_token  # specific
         self.revert_on_cancel = revert_on_cancel
         self.body_css_classes = body_css_classes if body_css_classes else self.configuration.get("bodyClass", "")
+        self.add_admin_css = add_admin_css
 
     def render_textarea(self, name, value, attrs=None, renderer=None):
         return super().render(name, value, attrs, renderer)


### PR DESCRIPTION
…iles only to be loaded into the admin for the editor

## Summary by Sourcery

New Features:
- Added an `admin_css` tuple to `RTEConfig` to specify CSS files to be loaded only in the admin interface.