### PR TITLE
feat: Add configurable block and inline styles for Tiptap

### DIFF
--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -373,7 +373,7 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
 DEFAULT_TOOLBAR_CMS = [
     ["Undo", "Redo"],
     ["CMSPlugins", "cmswidget", "-", "ShowBlocks"],
-    ["Format", "Styles", "InlineStyles", "BlockStyles"],
+    ["Format", "Styles", "BlockStyles", "InlineStyles"],
     ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [
@@ -399,7 +399,7 @@ DEFAULT_TOOLBAR_CMS = [
 DEFAULT_TOOLBAR_HTMLField = [
     ["Undo", "Redo"],
     ["ShowBlocks"],
-    ["Format", "Styles", "InlineStyles", "BlockStyles"],
+    ["Format", "Styles", "BlockStyles", "InlineStyles"],
     ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [

--- a/djangocms_text/editors.py
+++ b/djangocms_text/editors.py
@@ -320,6 +320,12 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
     "Styles": {
         "title": _("Styles"),
     },
+    "InlineStyles": {
+        "title": _("Styles"),
+    },
+    "BlockStyles": {
+        "title": _("Blocks"),
+    },
     "Font": {
         "title": _("Font"),
     },
@@ -367,7 +373,7 @@ _EDITOR_TOOLBAR_BASE_CONFIG = {
 DEFAULT_TOOLBAR_CMS = [
     ["Undo", "Redo"],
     ["CMSPlugins", "cmswidget", "-", "ShowBlocks"],
-    ["Format", "Styles"],
+    ["Format", "Styles", "InlineStyles", "BlockStyles"],
     ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [
@@ -393,7 +399,7 @@ DEFAULT_TOOLBAR_CMS = [
 DEFAULT_TOOLBAR_HTMLField = [
     ["Undo", "Redo"],
     ["ShowBlocks"],
-    ["Format", "Styles"],
+    ["Format", "Styles", "InlineStyles", "BlockStyles"],
     ["TextColor", "Highlight", "BGColor", "-", "PasteText", "PasteFromWord"],
     ["Maximize"],
     [
@@ -439,7 +445,7 @@ class RTEConfig:
         config: str,
         js: Iterable[str] | None = None,
         css: dict | None = None,
-        admin_css: dict | None = None,
+        admin_css: Iterable[str] | None = None,
         inline_editing: bool = False,
         child_plugin_support: bool = False,
     ):

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -19,7 +19,7 @@ import TableRow from '@tiptap/extension-table-row';
 import {TextAlign, TextAlignOptions} from '@tiptap/extension-text-align';
 import TiptapToolbar from "./tiptap_plugins/cms.tiptap.toolbar";
 
-import {TextColor, Small, Var, Kbd, Samp, Highlight, InlineQuote} from "./tiptap_plugins/cms.styles";
+import {TextColor, Small, Var, Kbd, Samp, Highlight, InlineQuote, InlineStyle, BlockStyle} from "./tiptap_plugins/cms.styles";
 import CmsFormExtension from "./tiptap_plugins/cms.formextension";
 import CmsToolbarPlugin from "./tiptap_plugins/cms.toolbar";
 
@@ -50,6 +50,7 @@ class CMSTipTapPlugin {
                 TableCell,
                 CmsDynLink,
                 Small, Var, Kbd, Samp, Highlight, InlineQuote,
+                InlineStyle, BlockStyle,
                 TextAlign.configure({
                     types: ['heading', 'paragraph'],
                 }),
@@ -119,6 +120,9 @@ class CMSTipTapPlugin {
                 save_callback: save_callback,
                 settings: settings,
                 toolbar: options.toolbar || options.toolbar_HTMLField,
+                stylesSet: options.stylesSet,
+                inlineStyles: options.inlineStyles || [],
+                blockStyles: options.blockStyles || [],
                 separator_markup: this.separator_markup,
                 space_markup: this.space_markup,
             });

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -122,6 +122,7 @@ class CMSTipTapPlugin {
                 toolbar: options.toolbar || options.toolbar_HTMLField,
                 inlineStyles: options.inlineStyles,
                 blockStyles: options.blockStyles,
+                textColors: options.textColors,
                 separator_markup: this.separator_markup,
                 space_markup: this.space_markup,
             });

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -19,7 +19,7 @@ import TableRow from '@tiptap/extension-table-row';
 import {TextAlign, TextAlignOptions} from '@tiptap/extension-text-align';
 import TiptapToolbar from "./tiptap_plugins/cms.tiptap.toolbar";
 
-import {TextColor, Small, Var, Kbd, Samp, Highlight, InlineQuote, InlineStyle, BlockStyle} from "./tiptap_plugins/cms.styles";
+import {TextColor, Highlight, InlineQuote, InlineStyle, BlockStyle} from "./tiptap_plugins/cms.styles";
 import CmsFormExtension from "./tiptap_plugins/cms.formextension";
 import CmsToolbarPlugin from "./tiptap_plugins/cms.toolbar";
 
@@ -49,7 +49,7 @@ class CMSTipTapPlugin {
                 TableHeader,
                 TableCell,
                 CmsDynLink,
-                Small, Var, Kbd, Samp, Highlight, InlineQuote,
+                Highlight, InlineQuote,
                 InlineStyle, BlockStyle,
                 TextAlign.configure({
                     types: ['heading', 'paragraph'],
@@ -120,9 +120,8 @@ class CMSTipTapPlugin {
                 save_callback: save_callback,
                 settings: settings,
                 toolbar: options.toolbar || options.toolbar_HTMLField,
-                stylesSet: options.stylesSet,
-                inlineStyles: options.inlineStyles || [],
-                blockStyles: options.blockStyles || [],
+                inlineStyles: options.inlineStyles,
+                blockStyles: options.blockStyles,
                 separator_markup: this.separator_markup,
                 space_markup: this.space_markup,
             });

--- a/private/js/tiptap_plugins/cms.dynlink.js
+++ b/private/js/tiptap_plugins/cms.dynlink.js
@@ -41,7 +41,6 @@ function DynLinkClickHandler(editor) {
 
 const CmsDynLink = Link.extend({
     addAttributes() {
-        'use strict';
         return {
             'data-cms-href': {
                 default: null

--- a/private/js/tiptap_plugins/cms.plugin.js
+++ b/private/js/tiptap_plugins/cms.plugin.js
@@ -127,6 +127,9 @@ TiptapToolbar.CMSPlugins.render = renderCmsPluginMenu;
 
 // Common node properties for both inline and block nodes
 const cmsPluginNodes = {
+    atom: true,
+    draggable: true,
+
     addAttributes() {
         'use strict';
         return {
@@ -143,10 +146,6 @@ const cmsPluginNodes = {
             editor: null,
         };
     },
-
-    atom: true,
-
-    draggable: true,
 
     parseHTML() {
         'use strict';

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -57,10 +57,9 @@ const Highlight = Mark.create({
 });
 
 
-function renderColorMenu(editor, builder) {
+function renderColorMenu(editor) {
     const items = [];
-    const mark = editor.extensionManager.extensions.find(extension => extension.name === 'textcolor');
-    for (const [cls, def] of Object.entries(mark.options?.textColors || {})) {
+    for (const [cls, def] of Object.entries(editor.options?.textColors || TextColor.options.textColors)) {
         items.push(`<button data-action="TextColor" data-class="${cls}" title="${def.name}" class="${cls}"></button>`);
     }
     return items.join('');
@@ -70,6 +69,7 @@ function renderColorMenu(editor, builder) {
 const TextColor = Mark.create({
     name: 'textcolor',
     addOptions() {
+        console.log(this.editor);
         return {
             textColors: {
                 'text-primary': {name: "Primary"},
@@ -86,13 +86,6 @@ const TextColor = Mark.create({
         };
     },
 
-    onCreate() {
-        if (this.editor.options.textColors) {
-            // Let editor options overwrite the default colors
-            this.options.textColors = this.editor.options.textColors;
-        }
-    },
-
     addAttributes() {
         return {
             class: { default: null },
@@ -101,6 +94,11 @@ const TextColor = Mark.create({
     },
 
     parseHTML() {
+        if (this.editor.options.textColors) {
+            // Let editor options overwrite the default colors
+            this.options.textColors = this.editor.options.textColors;
+        }
+
         return [
             {
                 tag: '*',
@@ -372,8 +370,8 @@ const BlockStyle = Node.create({
 });
 
 
-TiptapToolbar.InlineStyles.items = (editor, builder) => renderStyleMenu(editor.options.inlineStyles, editor, 'span');
-TiptapToolbar.BlockStyles.items = (editor, builder) => renderStyleMenu(editor.options.blockStyles || [], editor, 'div');
+TiptapToolbar.InlineStyles.items = (editor) => renderStyleMenu(editor.options.inlineStyles, editor, 'span');
+TiptapToolbar.BlockStyles.items = (editor) => renderStyleMenu(editor.options.blockStyles || [], editor, 'div');
 TiptapToolbar.TextColor.items = renderColorMenu;
 
 export {TextColor, Highlight, InlineQuote, InlineStyle, BlockStyle, TextColor as default};

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -174,7 +174,9 @@ function validateAttributes(node, styleAttributes) {
     if (!styleAttributes) {
         return true;
     }
-
+    if (!node?.classList) {
+        return false;
+    }
     if (styleAttributes.class) {
         const requiredClasses = styleAttributes.class.split(' ');
         if (!requiredClasses.every(cls => node.classList.contains(cls))) {

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -34,15 +34,6 @@ function generateTableMenu(editor, builder) {
     return generateButtonArray(10, 10) + builder(_tableMenu);
 }
 
-function generateColorMenu(editor, builder) {
-    let items = '';
-    const mark = editor.extensionManager.extensions.find(extension => extension.name === 'textcolor');
-    for (const [cls, def] of Object.entries(mark.options?.textColors || {})) {
-        items += `<button data-action="TextColor" data-class="${cls}" title="${def.name}" class="${cls}"></button>`;
-    }
-    return items;
-
-}
 
 const TiptapToolbar = {
     Undo: {
@@ -103,9 +94,9 @@ const TiptapToolbar = {
         },
         enabled: (editor) => editor.can().toggleTextColor(),
         active: (editor, button) => editor.isActive('textcolor', {class: button.dataset?.class}),
-        items: generateColorMenu,
         icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-fonts" viewBox="0 0 16 16"><path d="M12.258 3h-8.51l-.083 2.46h.479c.26-1.544.758-1.783 2.693-1.845l.424-.013v7.827c0 .663-.144.82-1.3.923v.52h4.082v-.52c-1.162-.103-1.306-.26-1.306-.923V3.602l.431.013c1.934.062 2.434.301 2.693 1.846h.479z"/></svg>',
         type: 'mark',
+        class: 'js-set-active-class',
     },
     InlineQuote: {
         action: (editor) => {
@@ -140,28 +131,20 @@ const TiptapToolbar = {
     },
     InlineStyles: {
         type: 'mark',
-        class: 'vertical',
+        class: 'vertical js-set-active-text',
         action: (editor, button) => {
-            if (editor.isActive('inlinestyle')) {
-                editor.chain().extendMarkRange('inlinestyle').unsetInlineStyle().run();
-            } else {
-                editor.commands.setInlineStyle(button.dataset?.id ||0);
-            }
+            editor.commands.toggleInlineStyle(button?.dataset?.id ||0);
         },
-        enabled: (editor, button) => editor.can().setInlineStyle(button.dataset?.id || 0),
-        active: (editor, button) => editor.commands.activeInlineStyle(button.dataset?.id || 0),
+        enabled: (editor, button) => editor.can().toggleInlineStyle(button?.dataset?.id || 0),
+        active: (editor, button) => editor.commands.activeInlineStyle(button?.dataset?.id || 0),
 
     },
     BlockStyles: {
         type: 'mark',
-        class: 'vertical',
-        action: (editor, button) => editor.commands.toggleBlockStyle(button.dataset?.id || 0),
-        enabled: (editor, button) => editor.can().toggleBlockStyle(button.dataset?.id || 0),
-        active: (editor, button) => editor.commands.blockStyleActive(button.dataset?.id || 0),
-    },
-    Styles: {
-        type: 'mark',
-        class: 'vertical',
+        class: 'vertical js-set-active-text',
+        action: (editor, button) => editor.commands.toggleBlockStyle(button?.dataset?.id || 0),
+        enabled: (editor, button) => editor.can().toggleBlockStyle(button?.dataset?.id || 0),
+        active: (editor, button) => editor.commands.activeBlockStyle(button?.dataset?.id || 0),
     },
     RemoveFormat: {
         action: (editor) => editor.commands.unsetAllMarks(),
@@ -322,18 +305,6 @@ const TiptapToolbar = {
         action: (editor) => editor.commands.toggleCode(),
         enabled: (editor) => editor.can().toggleCode(),
         active: (editor) => editor.isActive('code'),
-        type: 'mark',
-    },
-    Small: {
-        action: (editor) => editor.commands.toggleSmall(),
-        enabled: (editor) => editor.can().toggleSmall(),
-        active: (editor) => editor.isActive('Small'),
-        type: 'mark',
-    },
-    Kbd: {
-        action: (editor) => editor.commands.toggleKbd(),
-        enabled: (editor) => editor.can().toggleKbd(),
-        active: (editor) => editor.isActive('Kbd'),
         type: 'mark',
     },
     CodeBlock: {

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -6,14 +6,14 @@
 
 
 function generateButtonArray(rows, cols) {
-    let buttons = '<div class="tt-create-table">';
+    const buttons = ['<div class="tt-create-table">'];
     for (let j= 0; j < rows; j++) {
         for (let i = 0; i < cols; i++) {
-            buttons += `<button title="${i+1}x${j+1}" data-action="Table" style="--mx: ${i*12}px; --my: ${j*12+4}px;" data-rows="${j+1}" data-cols="${i+1}"></button>`;
+            buttons.push(`<button title="${i+1}x${j+1}" data-action="Table" style="--mx: ${i*12}px; --my: ${j*12+4}px;" data-rows="${j+1}" data-cols="${i+1}"></button>`);
         }
     }
-    buttons += '</div>';
-    return buttons;
+    buttons.push('</div>');
+    return buttons.join('');
 }
 
 const _tableMenu = [

--- a/private/js/tiptap_plugins/cms.tiptap.toolbar.js
+++ b/private/js/tiptap_plugins/cms.tiptap.toolbar.js
@@ -138,6 +138,31 @@ const TiptapToolbar = {
             '</svg>',
         type: 'mark',
     },
+    InlineStyles: {
+        type: 'mark',
+        class: 'vertical',
+        action: (editor, button) => {
+            if (editor.isActive('inlinestyle')) {
+                editor.chain().extendMarkRange('inlinestyle').unsetInlineStyle().run();
+            } else {
+                editor.commands.setInlineStyle(button.dataset?.id ||0);
+            }
+        },
+        enabled: (editor, button) => editor.can().setInlineStyle(button.dataset?.id || 0),
+        active: (editor, button) => editor.commands.activeInlineStyle(button.dataset?.id || 0),
+
+    },
+    BlockStyles: {
+        type: 'mark',
+        class: 'vertical',
+        action: (editor, button) => editor.commands.toggleBlockStyle(button.dataset?.id || 0),
+        enabled: (editor, button) => editor.can().toggleBlockStyle(button.dataset?.id || 0),
+        active: (editor, button) => editor.commands.blockStyleActive(button.dataset?.id || 0),
+    },
+    Styles: {
+        type: 'mark',
+        class: 'vertical',
+    },
     RemoveFormat: {
         action: (editor) => editor.commands.unsetAllMarks(),
         enabled: (editor) => editor.can().unsetAllMarks(),
@@ -331,7 +356,7 @@ const TiptapToolbar = {
     Heading1: {
         action: (editor) => editor.commands.setHeading({ level: 1 }),
         enabled: (editor) => editor.can().setHeading({ level: 1 }),
-        active: (editor) => editor.isActive('heading', {level: 1}),
+        active: (editor) => editor.isActive('heading', { level: 1 }),
         type: 'block',
     },
     Heading2: {

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -439,10 +439,12 @@ function _updateToolbar(editor, toolbar) {
     }
     for (const button of querySelector) {
         const {action} = button.dataset;
-        if (action && TiptapToolbar[action]) {
+        if (TiptapToolbar[action]) {
               const toolbarItem = window.cms_editor_plugin._getRepresentation(action);
               try {
-                  button.disabled = !toolbarItem?.enabled(editor, button);
+                  if (toolbarItem.enabled !== undefined) {
+                      button.disabled = !toolbarItem.enabled(editor, button);
+                  }
                   try {
                       if (toolbarItem.active && toolbarItem.active(editor, button)) {
                           button.classList.add('active');


### PR DESCRIPTION
## Summary by Sourcery

Add support for configurable inline and block styles, replacing the hardcoded small, kbd, var, and samp styles.

New Features:
- Introduce configurable inline and block styles in the editor.

Tests:
- Update tests to reflect the changes in the available styles.