### PR TITLE
fix: ModuleNotFoundError when CMS is not installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+0.6.0 (06-02-2025)
+==================
+
+* fix: Remove cms imports where not necessary by @fsbraun in  https://github.com/django-cms/djangocms-text/pull/56
+* fix: Avoid downcasting of text-enabled child plugins if plugins are already downcasted by @fsbraun in https://github.com/django-cms/djangocms-text/pull/58
+
 0.5.3 (18-01-2025)
 ==================
 * fix: Markup error disabled the block toolbar in inline editing

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"

--- a/djangocms_text/apps.py
+++ b/djangocms_text/apps.py
@@ -72,7 +72,7 @@ def check_ckeditor_settings(app_configs, **kwargs) -> list:  # pragma: no cover
                 f"The TEXT_ADDITIONAL_TAGS setting is deprecated and will be removed in a future release.\n"
                 f"{change_msg}",
                 f"TEXT_ADDITIONAL_ATTRIBUTES = "
-                f"""{{{', '.join([f'"{tag}": set()' for tag in settings.TEXT_ADDITIONAL_TAGS])}\"}}\n""",
+                f"""{{{", ".join([f'"{tag}": set()' for tag in settings.TEXT_ADDITIONAL_TAGS])}\"}}\n""",
                 id="text.W001",
                 obj="settings.TEXT_ADDITIONAL_TAGS",
             )

--- a/djangocms_text/apps.py
+++ b/djangocms_text/apps.py
@@ -6,6 +6,7 @@ class TextConfig(AppConfig):
     name = "djangocms_text"
     verbose_name = "django CMS Rich Text"
     default_auto_field = "django.db.models.BigAutoField"
+    inline_models: dict[str, str] = {}
 
     def ready(self):
         self.inline_models = discover_inline_editable_models()
@@ -13,14 +14,14 @@ class TextConfig(AppConfig):
         register(check_no_cms_config)
 
 
-def discover_inline_editable_models():
+def discover_inline_editable_models() -> dict[str, str]:
     # Find frontend-editable models and plugins
 
     from django.contrib.admin import site
 
     registered_inline_fields = ["HTMLFormField", "CharField"]
-    inline_models = {}
-    blacklist_apps = []
+    inline_models: dict[str, str] = {}
+    blacklist_apps: list[str] = []
 
     for model, modeladmin in site._registry.items():
         if model._meta.app_label in blacklist_apps:
@@ -57,14 +58,14 @@ def discover_inline_editable_models():
     return inline_models
 
 
-def check_ckeditor_settings(app_configs, **kwargs):  # pragma: no cover
+def check_ckeditor_settings(app_configs, **kwargs) -> list:  # pragma: no cover
     from django.conf import settings
 
     change_msg = (
         "Please use the TEXT_ADDITIONAL_ATTRIBUTES setting with a dictionary instead. "
         "Have an entry for each tag and specify allowed attributes for the tag as a set."
     )
-    warnings = []
+    warnings: list[Warning] = []
     if getattr(settings, "TEXT_ADDITIONAL_TAGS", None):
         warnings.append(
             Warning(
@@ -89,7 +90,7 @@ def check_ckeditor_settings(app_configs, **kwargs):  # pragma: no cover
     return warnings
 
 
-def check_no_cms_config(app_configs, **kwargs):  # pragma: no cover
+def check_no_cms_config(app_configs, **kwargs) -> list:  # pragma: no cover
     from django.conf import settings
 
     if "cms" in settings.INSTALLED_APPS:

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -163,7 +163,7 @@ def replace_plugin_tags(text: str, id_dict, regex: str = OBJ_ADMIN_RE) -> str:
             plugin_id = int(m.groupdict()["pk"])
             new_id = id_dict[plugin_id]
             plugin = plugins_by_id[new_id]
-        except KeyError:  # pragma nocover
+        except KeyError:  # pragma: no cover
             # Object must have been deleted.  It cannot be rendered to
             # end user, or edited, so just remove it from the HTML
             # altogether

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -11,7 +11,7 @@ try:
     from cms import __version__
     from cms.models import CMSPlugin
     from cms.utils.urlutils import admin_reverse
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
     from django.db import Model as CMSPlugin
     from django.urls import reverse
 
@@ -19,6 +19,7 @@ except ModuleNotFoundError:
 
     def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
         return reverse(f"admin:{viewname}", args, kwargs, current_app)
+
 
 from classytags.utils import flatten_context
 from packaging.version import Version
@@ -89,7 +90,7 @@ def plugin_to_tag(obj: CMSPlugin, content: str = "", admin: bool = False):
         plugin_attrs["preview"] = "true" if preview else "false"
         plugin_attrs["type"] = plugin_class.__name__
     else:
-        plugin_tag = '<cms-plugin alt="%(icon_alt)s" ' 'title="%(icon_alt)s" id="%(id)d">%(content)s</cms-plugin>'
+        plugin_tag = '<cms-plugin alt="%(icon_alt)s" title="%(icon_alt)s" id="%(id)d">%(content)s</cms-plugin>'
     return plugin_tag % plugin_attrs
 
 

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -162,7 +162,7 @@ def replace_plugin_tags(text: str, id_dict, regex: str = OBJ_ADMIN_RE) -> str:
             plugin_id = int(m.groupdict()["pk"])
             new_id = id_dict[plugin_id]
             plugin = plugins_by_id[new_id]
-        except KeyError:
+        except KeyError:  # pragma nocover
             # Object must have been deleted.  It cannot be rendered to
             # end user, or edited, so just remove it from the HTML
             # altogether

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -9,8 +9,10 @@ from django.template.loader import render_to_string
 
 try:
     from cms import __version__
+    from cms.models import CMSPlugin
     from cms.utils.urlutils import admin_reverse
 except ModuleNotFoundError:
+    from django.db import Model as CMSPlugin
     from django.urls import reverse
 
     __version__ = "0"

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -5,8 +5,17 @@ from functools import WRAPPER_ASSIGNMENTS, wraps
 from django.template.defaultfilters import force_escape
 from django.template.loader import render_to_string
 
-from cms import __version__
-from cms.utils.urlutils import admin_reverse
+try:
+    from cms import __version__
+    from cms.utils.urlutils import admin_reverse
+except ModuleNotFoundError:
+    from django.urls import reverse
+
+    __version__ = "0"
+
+    def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
+        return reverse(f"admin:{viewname}", args, kwargs, current_app)
+
 
 from classytags.utils import flatten_context
 from packaging.version import Version

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -14,22 +14,15 @@ from django.urls.exceptions import NoReverseMatch
 from django.utils.safestring import mark_safe
 from django.utils.translation.trans_real import get_language, gettext
 
-try:
-    from cms.utils.urlutils import admin_reverse, static_with_version
-except ModuleNotFoundError:
-    from django.urls import reverse
-
-    def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
-        return reverse(f"admin:{viewname}", args, kwargs, current_app)
-
-    def static_with_version(path):
-        return path
-    
-
 from . import settings as text_settings
 from .editors import DEFAULT_TOOLBAR_CMS, DEFAULT_TOOLBAR_HTMLField, get_editor_base_config, get_editor_config
-from .utils import cms_placeholder_add_plugin
+from .utils import admin_reverse, cms_placeholder_add_plugin
 
+try:
+    from cms.utils.urlutils import  static_with_version
+except ModuleNotFoundError:
+    def static_with_version(path):
+        return path
 
 rte_config = get_editor_config()
 #: The configuration for the text editor widget

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -19,10 +19,12 @@ from .editors import DEFAULT_TOOLBAR_CMS, DEFAULT_TOOLBAR_HTMLField, get_editor_
 from .utils import admin_reverse, cms_placeholder_add_plugin
 
 try:
-    from cms.utils.urlutils import  static_with_version
-except ModuleNotFoundError:
+    from cms.utils.urlutils import static_with_version
+except ModuleNotFoundError:  # pragma: no cover
+
     def static_with_version(path):
         return path
+
 
 rte_config = get_editor_config()
 #: The configuration for the text editor widget
@@ -138,7 +140,7 @@ class TextEditorWidget(forms.Textarea):
 
         self.editor_class = "CMS_Editor"
         if self.editor_class not in attrs.get("class", "").join(" "):
-            new_class = f'{attrs.get("class", "")} {self.editor_class}'
+            new_class = f"{attrs.get('class', '')} {self.editor_class}"
             attrs["class"] = new_class.strip()
         self.editor_settings_id = f"cms-cfg-{pk if pk else attrs.get('id', uuid.uuid4())}"
         self.global_settings_id = "cms-editor-cfg"

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -14,7 +14,17 @@ from django.urls.exceptions import NoReverseMatch
 from django.utils.safestring import mark_safe
 from django.utils.translation.trans_real import get_language, gettext
 
-from cms.utils.urlutils import admin_reverse, static_with_version
+try:
+    from cms.utils.urlutils import admin_reverse, static_with_version
+except ModuleNotFoundError:
+    from django.urls import reverse
+
+    def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
+        return reverse(f"admin:{viewname}", args, kwargs, current_app)
+
+    def static_with_version(path):
+        return path
+    
 
 from . import settings as text_settings
 from .editors import DEFAULT_TOOLBAR_CMS, DEFAULT_TOOLBAR_HTMLField, get_editor_base_config, get_editor_config

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -19,8 +19,6 @@ pytest-playwright>=0.4.0
 coverage
 tox
 
-# IMPORTANT: latest easy-thumbnails causes error since it returns with
-# floating point, but the tests are not prepared for this and even the lib
 easy-thumbnails
 
 # In order to run skipped tests uncomment the next lines:


### PR DESCRIPTION
Fixes #55

## Summary by Sourcery

Bug Fixes:
- Fixed a ModuleNotFoundError that occurred when the CMS was not installed.