### PR TITLE
fix(settings): Remove duplication of Link and Unlink from HTMLField default settings

### DIFF
--- a/private/js/cms.ckeditor4.js
+++ b/private/js/cms.ckeditor4.js
@@ -51,7 +51,6 @@ window.cms_editor_plugin = {
             ['Bold', 'Italic', 'Underline', 'Strike', '-', 'Subscript', 'Superscript', '-', 'RemoveFormat'],
             ['JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'],
             ['HorizontalRule'],
-            ['Link', 'Unlink'],
             ['NumberedList', 'BulletedList'],
             ['Outdent', 'Indent', '-', 'Blockquote', '-', 'Link', 'Unlink', '-', 'Table'],
             ['Source']


### PR DESCRIPTION
Same as https://github.com/django-cms/djangocms-text-ckeditor/pull/679

## Summary by Sourcery

Bug Fixes:
- Removes duplicated 'Link' and 'Unlink' buttons from the HTMLField default settings.