### PR TITLE
fix: Add warning due to changed setting

### DIFF
--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/djangocms_text/apps.py
+++ b/djangocms_text/apps.py
@@ -91,7 +91,7 @@ def check_ckeditor_settings(app_configs, **kwargs) -> list:  # pragma: no cover
     return warnings
 
 
-def check_ckeditor_settings_dict(settings: object) -> list:
+def check_ckeditor_settings_dict(settings: object) -> list:  # pragma: no cover
     def recursive_replace(config_list: list, old: str, new: str):
         changed = False
         for index, item in enumerate(config_list):


### PR DESCRIPTION
In the CKEDITOR_SETTINGS setting, the toolbar entry for `cmsplugins` is now called `CMSPlugins`.

## Summary by Sourcery

Adds a check to ensure that users are using the correct name for the cmsplugins toolbar entry in CKEDITOR_SETTINGS, and warns them if they are not. Also, increments the version number.