### PR TITLE
fix: Make toolbar sticky in modal

### DIFF
--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -58,7 +58,7 @@
                 height: auto;
             }
         }
-        position: static;
+        position: sticky;
         width: 100%;
         box-sizing: border-box;
         outline: none;


### PR DESCRIPTION
Fixes #65

## Summary by Sourcery

Bug Fixes:
- Resolve issue #65 by changing the toolbar positioning to sticky, ensuring it remains visible when scrolling within the modal