### PR TITLE
fix: Quit atomic block for mysql migration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,7 @@ source =
     djangocms_text
     djangocms_text_ckeditor
 omit =
-    migrations/*
+    djangocms_text/migrations/*
     tests/*
 
 [report]

--- a/djangocms_text/migrations/0004_remove_old_ckeditor_table.py
+++ b/djangocms_text/migrations/0004_remove_old_ckeditor_table.py
@@ -7,7 +7,12 @@ def drop_table_if_exists(apps, schema_editor):
         if schema_editor.connection.vendor == "postgresql":
             schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text CASCADE;")
         else:
-            schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text;")
+            in_atomic_block = schema_editor.connection.in_atomic_block
+            schema_editor.connection.in_atomic_block = False
+            try:
+                schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text;")
+            finally:
+                schema_editor.connection.in_atomic_block = in_atomic_block
 
 
 class Migration(migrations.Migration):

--- a/djangocms_text/migrations/0004_remove_old_ckeditor_table.py
+++ b/djangocms_text/migrations/0004_remove_old_ckeditor_table.py
@@ -6,13 +6,17 @@ def drop_table_if_exists(apps, schema_editor):
     if table_name in schema_editor.connection.introspection.table_names():
         if schema_editor.connection.vendor == "postgresql":
             schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text CASCADE;")
-        else:
+        elif schema_editor.connection.vendor == "mysql":
+            # MySQL does not support DROP TABLE inside an atomic block
             in_atomic_block = schema_editor.connection.in_atomic_block
             schema_editor.connection.in_atomic_block = False
             try:
                 schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text;")
             finally:
                 schema_editor.connection.in_atomic_block = in_atomic_block
+        else:
+            # For other databases, we can use the default behavior
+            schema_editor.execute("DROP TABLE IF EXISTS djangocms_text_ckeditor_text;")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This PR updates migration 0004 to run on mysql. 

Fixes #82

## Summary by Sourcery

Bug Fixes:
- Allow migration 0004 to drop the old CKEditor table on MySQL by temporarily disabling the atomic block.