### PR TITLE
fix: Support django CMS 5 data bridge for text-enabled plugins

### DIFF
--- a/djangocms_text/cms_plugins.py
+++ b/djangocms_text/cms_plugins.py
@@ -623,7 +623,7 @@ class TextPlugin(CMSPluginBase):
             page=page,
         )
         child_plugins = (get_plugin(name) for name in child_plugin_types)
-        template = getattr(self.page, "template", None)
+        template = getattr(page, "template", None)
 
         modules = get_placeholder_conf("plugin_modules", plugin.placeholder.slot, template, default={})
         names = get_placeholder_conf("plugin_labels", plugin.placeholder.slot, template, default={})

--- a/djangocms_text/fields.py
+++ b/djangocms_text/fields.py
@@ -23,7 +23,7 @@ class HTMLFormField(CharField):
     def clean(self, value):
         value = super().clean(value)
         value = render_dynamic_attributes(value, admin_objects=False, remove_attr=False)
-        clean_value = clean_html(value, full=False)
+        clean_value = clean_html(value)
 
         # We `mark_safe` here (as well as in the correct places) because Django
         # Parler cache's the value directly from the in-memory object as it

--- a/djangocms_text/html.py
+++ b/djangocms_text/html.py
@@ -95,7 +95,7 @@ cms_parser: NH3Parser = NH3Parser()
 #: An instance of NH3Parser with the default configuration for CMS text content.
 
 
-def clean_html(data: str, full: bool = False, cleaner: NH3Parser = None) -> str:
+def clean_html(data: str, full: Optional[bool] = None, cleaner: NH3Parser = None) -> str:
     """
     Cleans HTML from XSS vulnerabilities using nh3
     If full is False, only the contents inside <body> will be returned (without
@@ -105,11 +105,12 @@ def clean_html(data: str, full: bool = False, cleaner: NH3Parser = None) -> str:
     if settings.TEXT_HTML_SANITIZE is False:
         return data
 
-    warnings.warn(
-        "full argument is deprecated and will be removed",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
+    if full is not None:
+        warnings.warn(
+            "full argument is deprecated and will be removed",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     cleaner = cleaner or cms_parser
     return nh3.clean(data, **cleaner())
 

--- a/djangocms_text/models.py
+++ b/djangocms_text/models.py
@@ -79,7 +79,7 @@ if apps.is_installed("cms"):
             super().save(*args, **kwargs)
             body = self.body
             body = extract_images(body, self)
-            body = clean_html(body, full=False)
+            body = clean_html(body)
             if settings.TEXT_AUTO_HYPHENATE:
                 try:
                     body = hyphenate(body, language=self.language)

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -491,18 +491,16 @@ class CMSEditor {
 
         if (script && script.textContent.length > 2) {
             this.CMS.API.Helpers.dataBridge = JSON.parse(script.textContent);
-            console.log("CMS.API.Helpers.dataBridge", this.CMS.API.Helpers.dataBridge);
         } else {
-            const regex1 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\s=\s(.*?);$/gmu.exec(body);
-            const regex2 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\.structure\s=\s(.*?);$/gmu.exec(body);
+            const regex1 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\s=\s(.*?);$/gmu.exec(dom.innerHTML);
+            const regex2 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\.structure\s=\s(.*?);$/gmu.exec(dom.innerHTML);
 
             if (regex1 && regex2 && this.CMS) {
                 this.CMS.API.Helpers.dataBridge = JSON.parse(regex1[1]);
                 this.CMS.API.Helpers.dataBridge.structure = JSON.parse(regex2[1]);
-                console.log("CMS.API.Helpers.dataBridge by REGEX", this.CMS.API.Helpers.dataBridge);
             } else {
                 // No databridge found
-                this.CMS.API.Helpers.dataBridge = {};
+                this.CMS.API.Helpers.dataBridge = null;
             }
         }
         // Additional content for the page disrupts inline editing and needs to be removed

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -449,24 +449,13 @@ class CMSEditor {
                         }
 
                     }
-                    const script = dom.querySelector('script#data-bridge');
                     el.dataset.changed = 'false';
-                    if (script && script.textContent.length > 2) {
-                        this.CMS.API.Helpers.dataBridge = JSON.parse(script.textContent);
-                    } else {
-                        const regex1 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\s=\s(.*?);$/gmu.exec(body);
-                        const regex2 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\.structure\s=\s(.*?);$/gmu.exec(body);
-                        if (regex1 && regex2 && this.CMS) {
-                            this.CMS.API.Helpers.dataBridge = JSON.parse(regex1[1]);
-                            this.CMS.API.Helpers.dataBridge.structure = JSON.parse(regex2[1]);
-                        } else {
-                            // No databridge found: reload
-                            this.CMS.API.Helpers.reloadBrowser('REFRESH_PAGE');
-                            return;
-                        }
+                    this.processDataBridge(dom);
+                    if (!this.CMS.API.Helpers.dataBridge) {
+                        // No databridge found
+                        this.CMS.API.Helpers.reloadBrowser('REFRESH_PAGE');
+                        return;
                     }
-                    // Additional content for the page disrupts inline editing and needs to be removed
-                    delete this.CMS.API.Helpers.dataBridge.structure?.content;
 
                     if (this.CMS.settings.version.startsWith('3.')) {
                         /* Reflect dirty flag in django CMS < 4 */
@@ -495,6 +484,29 @@ class CMSEditor {
                     window.console.log(error.stack);
                 });
         }
+    }
+
+    processDataBridge(dom) {
+        const script = dom.querySelector('script#data-bridge');
+
+        if (script && script.textContent.length > 2) {
+            this.CMS.API.Helpers.dataBridge = JSON.parse(script.textContent);
+            console.log("CMS.API.Helpers.dataBridge", this.CMS.API.Helpers.dataBridge);
+        } else {
+            const regex1 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\s=\s(.*?);$/gmu.exec(body);
+            const regex2 = /^\s*Window\.CMS\.API\.Helpers\.dataBridge\.structure\s=\s(.*?);$/gmu.exec(body);
+
+            if (regex1 && regex2 && this.CMS) {
+                this.CMS.API.Helpers.dataBridge = JSON.parse(regex1[1]);
+                this.CMS.API.Helpers.dataBridge.structure = JSON.parse(regex2[1]);
+                console.log("CMS.API.Helpers.dataBridge by REGEX", this.CMS.API.Helpers.dataBridge);
+            } else {
+                // No databridge found
+                this.CMS.API.Helpers.dataBridge = {};
+            }
+        }
+        // Additional content for the page disrupts inline editing and needs to be removed
+        delete this.CMS.API.Helpers.dataBridge.structure?.content;
     }
 
     // CMS Editor: addPluginForm
@@ -554,19 +566,13 @@ class CMSEditor {
                 el.dataset.changed = 'true';
                 // Hook into the django CMS dataBridge to get the details of the newly created or saved
                 // plugin. For new plugins we need their id to get the content.
+
                 if (!this.CMS.API.Helpers.dataBridge) {
-                    // The dataBridge sets a timer, so typically it will not yet be present
-                    setTimeout(() => {
-                        // Needed to update StructureBoard
-                        if (onSave) {
-                            onSave(el, form, this.CMS.API.Helpers.dataBridge);
-                        }
-                    }, 100);
-                } else {
-                    // Needed to update StructureBoard
-                    if (onSave) {
-                        onSave(el, form, this.CMS.API.Helpers.dataBridge);
-                    }
+                    this.processDataBridge(form);
+                }
+                // Needed to update StructureBoard
+                if (onSave && this.CMS.API.Helpers.dataBridge) {
+                    onSave(el, form, this.CMS.API.Helpers.dataBridge);
                 }
                 //  Do callback
             } else if (onLoad) {

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -53,7 +53,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         settings.TEXT_ADDITIONAL_ATTRIBUTES = {}
         text = html.clean_html(
             '<iframe src="rtmp://testurl.com/"></iframe>',
-            full=False,
             cleaner=NH3Parser(),
         )
         self.assertNotIn("iframe", NH3Parser().ALLOWED_TAGS)
@@ -65,7 +64,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
     def test_custom_tag_enabled(self):
         text = html.clean_html(
             '<iframe src="https://testurl.com/"></iframe>',
-            full=False,
             cleaner=NH3Parser(
                 additional_attributes={"iframe": {"src"}},
             ),
@@ -78,7 +76,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
     def test_default_attribute_escaping(self):
         text = html.clean_html(
             '<span test-attr="2">foo</span>',
-            full=False,
             cleaner=NH3Parser(),
         )
         self.assertEqual(
@@ -89,7 +86,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
     def test_custom_attribute_enabled(self):
         text = html.clean_html(
             '<span test-attr="2">foo</span>',
-            full=False,
             cleaner=NH3Parser(
                 additional_attributes={
                     "span": {"test-attr"},
@@ -105,14 +101,13 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         settings.TEXT_ADDITIONAL_PROTOCOLS = []
         text = html.clean_html(
             '<source src="rtmp://testurl.com/">',
-            full=False,
             cleaner=NH3Parser(),
         )
         self.assertEqual("<source>", text)
 
     def test_custom_protocol_enabled(self):
         settings.TEXT_ADDITIONAL_PROTOCOLS = ["rtmp"]
-        text = html.clean_html('<source src="rtmp://testurl.com/">', full=False, cleaner=NH3Parser())
+        text = html.clean_html('<source src="rtmp://testurl.com/">', cleaner=NH3Parser())
         self.assertEqual('<source src="rtmp://testurl.com/">', text)
 
     def test_clean_html_with_sanitize_enabled(self):
@@ -122,7 +117,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         original = '<span test-attr="2">foo</span>'
         cleaned = html.clean_html(
             original,
-            full=False,
         )
         try:
             self.assertHTMLEqual("<span>foo</span>", cleaned)
@@ -136,7 +130,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         original = '<span test-attr="2" onclick="alert();">foo</span>'
         cleaned = html.clean_html(
             original,
-            full=False,
         )
         try:
             self.assertHTMLEqual(original, cleaned)
@@ -147,7 +140,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         original = '<span aria-label="foo">foo</span>'
         cleaned = html.clean_html(
             original,
-            full=False,
         )
         self.assertHTMLEqual(original, cleaned)
 
@@ -155,7 +147,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         original = '<span data-test-attr="foo">foo</span>'
         cleaned = html.clean_html(
             original,
-            full=False,
         )
         self.assertHTMLEqual(original, cleaned)
 
@@ -163,7 +154,6 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         original = '<span role="button">foo</span>'
         cleaned = html.clean_html(
             original,
-            full=False,
         )
         self.assertHTMLEqual(original, cleaned)
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -28,7 +28,6 @@ class WidgetTestCase(TestFixture, BaseTestCase):
             body="some text",
         )
         endpoint = self.get_change_plugin_uri(plugin)
-
         with self.login_user_context(self.super_user):
             response = self.client.get(endpoint)
             self.assertContains(response, '"group": "Extra"')


### PR DESCRIPTION
This PR fixes #86 : 

django CMS 5's data bridge (the data connection between JS frontend editor and the `cms` app) has a new format. Now, djangocms-text accepts django CMS 3.11, 4.1, and 5.0 data bridge formats for both inline editing and adding text-enabled plugins.

## Summary by Sourcery

Add compatibility with django CMS 5 data bridge formats and refactor JS and Python code to streamline data bridge handling and HTML sanitization, including deprecation of the clean_html full flag and test adjustments.

New Features:
- Support Django CMS 5 data bridge format for inline editing and plugin additions

Bug Fixes:
- Correct template variable lookup in cms_plugins.get_plugins
- Trigger full page reload when no data bridge is found

Enhancements:
- Refactor CMS editor JS by extracting data bridge parsing into a new processDataBridge method
- Make clean_html's full parameter optional and emit deprecation warning only when provided

Tests:
- Remove deprecated full=False arguments in clean_html calls across tests
- Clean up unused lines in widget test