### PR TITLE
chore: Prepare release 0.8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests and CodeCov
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   unit-tests:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+0.8.5 (15-05-2025)
+==================
+
+* fix: Quit atomic block for mysql migration by @fsbraun in https://github.com/django-cms/djangocms-text/pull/85
+* fix: Support django CMS 5 data bridge for text-enabled plugins by @fsbraun in https://github.com/django-cms/djangocms-text/pull/87
+
+
 0.8.4 (09-05-2025)
 ==================
 

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 0.8.5 release by updating the package version and CHANGELOG.

Chores:
- Bump package version to 0.8.5 in __init__.py
- Update CHANGELOG.rst for the 0.8.5 release