### PR TITLE
Set CKEDITOR_BASEPATH via data-attribute on script src

### DIFF
--- a/djangocms_text/contrib/text_ckeditor4/__init__.py
+++ b/djangocms_text/contrib/text_ckeditor4/__init__.py
@@ -1,10 +1,24 @@
-from djangocms_text.editors import RTEConfig
-
+from cms.utils.urlutils import static_with_version
 from django.conf import settings
 from django.templatetags.static import static
-
-from cms.utils.urlutils import static_with_version
 from django.utils.functional import lazy
+from django.utils.html import format_html, html_safe
+
+from djangocms_text.editors import RTEConfig
+
+
+@html_safe
+class BasePath:
+    def __str__(self):
+        return format_html(
+            '<script src="{scriptsrc}" data-ckeditor-basepath="{basepath}"></script>',
+            scriptsrc=static("djangocms_text/js/basepath.js"),
+            basepath=getattr(
+                settings,
+                "TEXT_CKEDITOR_BASE_PATH",
+                lazy(static, str)("djangocms_text/vendor/ckeditor4/"),
+            ),
+        )
 
 
 ckeditor4 = RTEConfig(
@@ -12,16 +26,11 @@ ckeditor4 = RTEConfig(
     config="CKEDITOR",
     js=(
         static_with_version("cms/js/dist/bundle.admin.base.min.js"),
-        "djangocms_text/js/basepath.js",
+        BasePath(),
         "djangocms_text/vendor/ckeditor4/ckeditor.js",
         "djangocms_text/bundles/bundle.ckeditor4.min.js",
     ),
     css={"all": ("djangocms_text/css/cms.ckeditor4.css",)},
     inline_editing=True,
     child_plugin_support=True,
-    additional_context=dict(
-        CKEDITOR_BASEPATH=getattr(
-            settings, "TEXT_CKEDITOR_BASE_PATH", lazy(static, str)("djangocms_text/vendor/ckeditor4/")
-        ),
-    ),
 )

--- a/djangocms_text/contrib/text_ckeditor4/static/djangocms_text/js/basepath.js
+++ b/djangocms_text/contrib/text_ckeditor4/static/djangocms_text/js/basepath.js
@@ -3,4 +3,5 @@
 // It's loaded in this script since we avoid inline scripts (to better support CSP headers) and it needs to be
 // set before the CKEditor script is loaded which in turn needs to be loaded before the integration script.
 
-window.CKEDITOR_BASEPATH = JSON.parse(document.getElementById('cms-editor-cfg').textContent).CKEDITOR_BASEPATH;
+window.CKEDITOR_BASEPATH = document.currentScript.dataset.ckeditorBasepath
+


### PR DESCRIPTION
## Summary by Sourcery

Set CKEDITOR_BASEPATH via a data attribute on the basepath loader script and update the JS loader to source it from document.currentScript.dataset, removing the inline config context for improved CSP support.

Enhancements:
- Embed CKEDITOR_BASEPATH in a data-ckeditor-basepath attribute on the basepath.js script tag using a new BasePath helper and update basepath.js to read from document.currentScript.dataset.
- Remove the additional_context-based CKEDITOR_BASEPATH injection from RTEConfig to consolidate configuration.