### PR TITLE
chore: Prepare release 0.8.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.8.7 (30-05-2025)
+==================
+* fix: table icons of inline ckeditor respect dark mode by @PeterW-LWL in https://github.com/django-cms/djangocms-text/pull/92
+* feat: Add `CKEDITOR_BASEPATH` configuration for CKEditor 4 by @fsbraun in https://github.com/django-cms/djangocms-text/pull/94
+
+**New Contributor**
+
+@PeterW-LWL made their first contribution in https://github.com/django-cms/djangocms-text/pull/92
+
 0.8.6 (23-05-2025)
 ==================
 
@@ -48,6 +57,7 @@ Changelog
 * fix: Leaner event management by @fsbraun
 
 **New Contributors**
+
 * @DmytroLitvinov made their first contribution in https://github.com/django-cms/djangocms-text/pull/67
 * @earthcomfy made their first contribution in https://github.com/django-cms/djangocms-text/pull/61
 
@@ -175,8 +185,9 @@ Changelog
 * fix: Prepare css for drag / swipe in rtl mode by @fsbraun in https://github.com/django-cms/djangocms-text/pull/9
 * fix: Add bundles to build
 
-**New Contributors**
-* @MacLake made their first contribution in https://github.com/django-cms/djangocms-text/pull/11
+**New Contributor**
+
+@MacLake made their first contribution in https://github.com/django-cms/djangocms-text/pull/11
 
 0.1.0 (First alpha)
 ===================

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -5,10 +5,10 @@ Release logic:
  1. Increase version number (change __version__ below).
  2. Assure that all changes have been documented in CHANGELOG.rst.
  3. In ``pyproject.toml`` check that
-   - versions from all third party packages are pinned in ``REQUIREMENTS``.
-   - the list of ``CLASSIFIERS`` is up to date.
- 4. git add djangocms_text_ckeditor/__init__.py CHANGELOG.rst setup.py
- 5. git commit -m 'Bump to {new version}'
+   - versions from all third party packages are pinned in ``requirements``.
+   - the list of ``classifiers`` is up to date.
+ 4. git add djangocms_text/__init__.py CHANGELOG.rst setup.py
+ 5. git commit -m 'chore: Bump to {new version}'
  6. git push
  7. Assure that all tests pass on https://github.com/django-cms/djangocms-text-ckeditor/actions
  8. Create a new release on https://github.com/django-cms/djangocms-text-ckeditor/releases/new

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -4,7 +4,7 @@ See PEP 440 (https://www.python.org/dev/peps/pep-0440/)
 Release logic:
  1. Increase version number (change __version__ below).
  2. Assure that all changes have been documented in CHANGELOG.rst.
- 3. In setup.py check that
+ 3. In ``pyproject.toml`` check that
    - versions from all third party packages are pinned in ``REQUIREMENTS``.
    - the list of ``CLASSIFIERS`` is up to date.
  4. git add djangocms_text_ckeditor/__init__.py CHANGELOG.rst setup.py

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
+  "Framework :: Django :: 5.2",
   "Framework :: Django CMS",
   "Framework :: Django CMS :: 3.11",
   "Framework :: Django CMS :: 4.0",


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 0.8.7 by bumping the version, updating release instructions, and adding Django 5.2 to supported classifiers

Build:
- Add Django 5.2 to supported framework classifiers in pyproject.toml
- Update release instructions to reference pyproject.toml instead of setup.py

Chores:
- Bump package version to 0.8.7