### PR TITLE
feat: Add support for pasting Markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -352,6 +352,12 @@ If django CMS is not installed with django CMS Text, add the following to your
 
 This will prevent the creation of the model for the django CMS text plugin.
 
+Markdown-support
+----------------
+The TipTap frontend supports some (minimal) Markdown support:
+* Markdown is converted to HTML when **pasting**.
+* When typing, **some** markdown syntax is converted on the fly, e.g., headings, bold, lists
+
 
 Development
 ===========

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -22,6 +22,7 @@ import TiptapToolbar from "./tiptap_plugins/cms.tiptap.toolbar";
 import {TextColor, Highlight, InlineQuote, InlineStyle, BlockStyle} from "./tiptap_plugins/cms.styles";
 import CmsFormExtension from "./tiptap_plugins/cms.formextension";
 import CmsToolbarPlugin from "./tiptap_plugins/cms.toolbar";
+import markdownPasteHandler from './tiptap_plugins/cms.markdown';
 
 import '../css/cms.tiptap.css';
 
@@ -58,6 +59,7 @@ class CMSTipTapPlugin {
                 CmsBlockPluginNode,
                 CmsFormExtension,
                 CmsToolbarPlugin,
+                markdownPasteHandler,
             ],
             toolbar_HTMLField: [
                 ['Paragraph', '-', 'Heading1', 'Heading2', 'Heading3', 'Heading4', 'Heading5'], '|',

--- a/private/js/tiptap_plugins/cms.markdown.js
+++ b/private/js/tiptap_plugins/cms.markdown.js
@@ -1,0 +1,58 @@
+/* eslint-env es11 */
+/* jshint esversion: 11 */
+/* global document, window, console */
+'use strict';
+
+import {Extension} from "@tiptap/core";
+import {Plugin} from "@tiptap/pm/state";
+import showdown from "showdown";
+
+
+function isProbablyMarkdown(text) {
+    // Check for typical Markdown elements
+    const markdownPatterns = [
+        /^#{1,6}\s/m,           // Headings: #, ##, ...
+        /\*\*.*\*\*/m,          // Bold: **text**
+        /\*.*\*/m,              // Italic: *text*
+        /\[.*\]\(.*\)/m,        // Links: [text](url)
+        /^>\s/m,                // Blockquote: >
+        /^-\s/m,                // Lists: - item
+        /^(\d+\.)\s/m,          // Numbered lists: 1. item
+        /`[^`]+`/m,             // Inline-Code: `code`
+        /^```/m                 // Code blocks: ```
+    ];
+    return text && markdownPatterns.some(pattern => pattern.test(text));
+}
+
+const markdownPasteHandler = Extension.create({
+    name: 'markdownPasteHandler',
+
+    addProseMirrorPlugins() {
+        const editor = this.editor;
+
+        return [
+            new Plugin({
+                props: {
+                    handlePaste(view, event, slice) {
+                        // Your custom paste logic here
+                        // Example: get plain text from clipboard
+                        const text = event.clipboardData?.getData('text/plain');
+                        if (isProbablyMarkdown(text)) {
+                            const converter = new showdown.Converter(window.cms_editor_plugin?.markdownOptions || {
+                                tables: true,
+                                strikethrough: true,
+                                tasklists: true
+                            });
+                            const html = converter.makeHtml(text);
+                            editor.commands.insertContent(html);
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+            })
+        ];
+    }
+});
+
+export default markdownPasteHandler;


### PR DESCRIPTION
This PR adds support for pasting markdown into the TipTap editor. The markdown is converted into HTML before inserting. The plugin uses the [showdown.js ](https://github.com/showdownjs/showdown) library.