### PR TITLE
chore: Prepare release 0.9.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+0.9.2 (10-08-2025)
+==================
+
+* fix: Broken linkfield selector by @fsbraun in https://github.com/django-cms/djangocms-text/pull/105
+* fix: Trim values in linkfield by @fsbraun in https://github.com/django-cms/djangocms-text/pull/107
+* fix: Remove `static` command around JS assets of the toolbar by @fsbraun in https://github.com/django-cms/djangocms-text/pull/106
+* chore: Introduce dynamic badges by @mrbazzan in https://github.com/django-cms/djangocms-text/pull/108
+
+@mrbazzan made their first contribution in https://github.com/django-cms/djangocms-text/pull/108
+
+
 0.9.1 (12-06-2025)
 ==================
 

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 0.9.2 by bumping the package version and updating the changelog.

Documentation:
- Update CHANGELOG for version 0.9.2

Chores:
- Bump package version to 0.9.2