### PR TITLE
fix: Fixed issues for non-CMS installations and added test coverage for non-CMS installations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           dj50_cms41.txt,
           dj51_cms41.txt,
           dj52_cms50.txt,
+          dj52.txt,
         ]
         os: [
           ubuntu-latest,

--- a/djangocms_text/templates/cms/plugins/widgets/editor.html
+++ b/djangocms_text/templates/cms/plugins/widgets/editor.html
@@ -1,1 +1,1 @@
-{% load i18n l10n static cms_static sekizai_tags %}{{ editor_settings|json_script:editor_settings_id }}{% if global_settings %}{{ global_settings|json_script:global_settings_id }}{% endif %}
+{{ editor_settings|json_script:editor_settings_id }}{% if global_settings %}{{ global_settings|json_script:global_settings_id }}{% endif %}

--- a/djangocms_text/utils.py
+++ b/djangocms_text/utils.py
@@ -12,7 +12,8 @@ try:
     from cms.models import CMSPlugin
     from cms.utils.urlutils import admin_reverse
 except ModuleNotFoundError:  # pragma: no cover
-    from django.db import Model as CMSPlugin
+    from django.db.models import Model as CMSPlugin
+
     from django.urls import reverse
 
     __version__ = "0"
@@ -21,7 +22,6 @@ except ModuleNotFoundError:  # pragma: no cover
         return reverse(f"admin:{viewname}", args, kwargs, current_app)
 
 
-from classytags.utils import flatten_context
 from packaging.version import Version
 
 
@@ -38,7 +38,9 @@ else:
 
 
 def _render_cms_plugin(plugin: CMSPlugin, context):
-    context = flatten_context(context)
+    if callable(getattr(context, "flatten", None)):
+        context = context.flatten()
+
     context["plugin"] = plugin
 
     # This my fellow enthusiasts is a hack..

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -1,4 +1,3 @@
-import importlib.util
 import json
 import uuid
 from copy import deepcopy
@@ -18,6 +17,7 @@ from django.utils.translation.trans_real import get_language, gettext
 from . import settings as text_settings
 from .editors import DEFAULT_TOOLBAR_CMS, DEFAULT_TOOLBAR_HTMLField, get_editor_config
 from .utils import admin_reverse, cms_placeholder_add_plugin
+from .utils import __version__ as cms_version
 
 
 @cache
@@ -233,7 +233,7 @@ class TextEditorWidget(forms.Textarea):
 
         return {
             "add_plugin_url": (
-                admin_reverse(cms_placeholder_add_plugin) if importlib.util.find_spec("cms") is not None else ""
+                admin_reverse(cms_placeholder_add_plugin) if cms_version != "0" else ""
             ),
             "url_endpoint": self.url_endpoint or get_url_endpoint(),
             "static_url": settings.STATIC_URL + "djangocms_text" if settings.STATIC_URL else "",

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import uuid
 from copy import deepcopy
@@ -231,7 +232,9 @@ class TextEditorWidget(forms.Textarea):
             }
 
         return {
-            "add_plugin_url": admin_reverse(cms_placeholder_add_plugin),
+            "add_plugin_url": (
+                admin_reverse(cms_placeholder_add_plugin) if importlib.util.find_spec("cms") is not None else ""
+            ),
             "url_endpoint": self.url_endpoint or get_url_endpoint(),
             "static_url": settings.STATIC_URL + "djangocms_text" if settings.STATIC_URL else "",
             "lang": toolbar_setting,

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,7 +2,10 @@ import os
 
 from django.conf import settings
 
-from cms.test_utils.testcases import CMSTestCase
+try:
+    from cms.test_utils.testcases import CMSTestCase
+except ModuleNotFoundError:  # pragma: no cover
+    from django.test import TestCase as CMSTestCase
 
 
 class BaseTestCase(CMSTestCase):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,15 +1,21 @@
 from django.apps import apps
 
-from cms import __version__
-from cms.api import create_page
+DJANGO_CMS4 = False
 
 try:
-    from cms.api import create_page_content
-except ImportError:
-    from cms.api import create_title as create_page_content
+    from cms import __version__
+    from cms.api import create_page
 
+    try:
+        from cms.api import create_page_content
+    except ImportError:
+        from cms.api import create_title as create_page_content
 
-DJANGO_CMS4 = not (__version__ < "4")
+    DJANGO_CMS4 = not (__version__ < "4")
+
+except ModuleNotFoundError:
+    DJANGO_CMS4 = False
+
 DJANGOCMS_VERSIONING = apps.is_installed("djangocms_verisoning")
 
 

--- a/tests/integration/test_ckeditor4.py
+++ b/tests/integration/test_ckeditor4.py
@@ -1,5 +1,15 @@
 import pytest
-from cms.utils.urlutils import admin_reverse
+
+try:
+    from cms.utils.urlutils import admin_reverse
+except ModuleNotFoundError:
+
+    def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
+        from django.urls import reverse
+
+        return reverse(f"admin:{viewname}", args, kwargs, current_app)
+
+
 from playwright.sync_api import expect
 
 from tests.fixtures import DJANGO_CMS4

--- a/tests/integration/test_text_editor.py
+++ b/tests/integration/test_text_editor.py
@@ -1,5 +1,15 @@
 import pytest
-from cms.utils.urlutils import admin_reverse
+
+try:
+    from cms.utils.urlutils import admin_reverse
+except ModuleNotFoundError:
+
+    def admin_reverse(viewname, args=None, kwargs=None, current_app=None):
+        from django.urls import reverse
+
+        return reverse(f"admin:{viewname}", args, kwargs, current_app)
+
+
 from playwright.sync_api import expect
 
 from tests.fixtures import DJANGO_CMS4

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,7 +1,5 @@
 # requirements from setup.py
 django-filer>=1.4.0
-djangocms-picture>=2.1.0
-djangocms-link>=5.0.0
 django-polymorphic>=2.0.3
 Pillow
 html5lib>=0.999999999

--- a/tests/requirements/dj42_cms311.txt
+++ b/tests/requirements/dj42_cms311.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r dj_cms.txt
 
 Django>=4.2,<5.0
 django-cms>=3.11,<3.12

--- a/tests/requirements/dj42_cms41.txt
+++ b/tests/requirements/dj42_cms41.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r dj_cms.txt
 
 Django>=4.2,<5.0
 django-cms>=4.1,<4.2

--- a/tests/requirements/dj50_cms41.txt
+++ b/tests/requirements/dj50_cms41.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r dj_cms.txt
 
 Django~=5.0,<5.1
 django-cms>=4.1,<4.2

--- a/tests/requirements/dj51_cms41.txt
+++ b/tests/requirements/dj51_cms41.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r dj_cms.txt
 
 Django>=5.1,<5.2
 django-cms>=4.1,<4.2

--- a/tests/requirements/dj52.txt
+++ b/tests/requirements/dj52.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+Django>=5.2,<5.3

--- a/tests/requirements/dj52_cms50.txt
+++ b/tests/requirements/dj52_cms50.txt
@@ -1,4 +1,4 @@
--r base.txt
+-r dj_cms.txt
 
 Django>=5.2,<5.3
 django-cms>=5.0.0a1,<5.1

--- a/tests/requirements/dj_cms.txt
+++ b/tests/requirements/dj_cms.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+djangocms-picture>=2.1.0
+djangocms-link>=5.0.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,8 @@
 import os
 from tempfile import mkdtemp
+import importlib.util
+
+CMS_NOT_USED = importlib.util.find_spec("cms") is None
 
 
 def gettext(s):
@@ -14,7 +17,7 @@ class DisableMigrations(dict):
         return None
 
 
-MIGRATION_MODULES = DisableMigrations()
+MIGRATION_MODULES = {"djangocms_text": None} if CMS_NOT_USED else DisableMigrations()
 
 SECRET_KEY = "djangocms-text-test-suite"
 
@@ -28,26 +31,37 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "easy_thumbnails",
     "filer",
-    "cms",
-    "menus",
-    "treebeard",
-    "sekizai",
-    "djangocms_picture",
-    "djangocms_link",
     "djangocms_text",
-    "djangocms_text.contrib.text_ckeditor4",
     "tests.test_app",
-]
+] + (
+    []
+    if CMS_NOT_USED
+    else [
+        "menus",
+        "sekizai",
+        "treebeard",
+        "cms",
+        "djangocms_text.contrib.text_ckeditor4",
+        "djangocms_picture",
+        "djangocms_link",
+    ]
+)
+
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "cms.middleware.user.CurrentUserMiddleware",
-    "cms.middleware.page.CurrentPageMiddleware",
-    "cms.middleware.toolbar.ToolbarMiddleware",
-    "cms.middleware.language.LanguageCookieMiddleware",
-]
+] + (
+    []
+    if CMS_NOT_USED
+    else [
+        "cms.middleware.user.CurrentUserMiddleware",
+        "cms.middleware.page.CurrentPageMiddleware",
+        "cms.middleware.toolbar.ToolbarMiddleware",
+        "cms.middleware.language.LanguageCookieMiddleware",
+    ]
+)
 
 TEMPLATES = [
     {

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 
-from cms.models import CMSPlugin
+try:
+    from cms.models import CMSPlugin
+except ModuleNotFoundError:
+    from django.db.models import Model as CMSPlugin
 
 from djangocms_text.fields import HTMLField
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,16 +1,25 @@
 import copy
+from unittest import skipIf
 from unittest.mock import patch, MagicMock
-
-from cms.api import create_page, add_plugin
-from cms.test_utils.testcases import CMSTestCase
 from django.test import TestCase
-from lxml.etree import Element
 
-from djangocms_text import html, settings
-from djangocms_text.html import NH3Parser, dynamic_href, dynamic_src, render_dynamic_attributes
+try:
+    from cms.api import create_page, add_plugin
+    from cms.test_utils.testcases import CMSTestCase
+    from lxml.etree import Element
+
+    from djangocms_text import html, settings
+    from djangocms_text.html import NH3Parser, dynamic_href, dynamic_src, render_dynamic_attributes
+
+    SKIP_CMS_TEST = False
+except ModuleNotFoundError:
+    from django.test.utils import TestCase as CMSTestCase
+
+    SKIP_CMS_TEST = True
 from tests.fixtures import DJANGO_CMS4, TestFixture
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class SanitizerTestCase(TestCase):
     def test_sanitizer(self):
         body = '<span data-one="1" data-two="2">some text</span>'
@@ -48,6 +57,7 @@ class SanitizerTestCase(TestCase):
         settings.TEXT_ADDITIONAL_ATTRIBUTES = original_global_attributes
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
     def test_default_tag_removal(self):
         settings.TEXT_ADDITIONAL_ATTRIBUTES = {}
@@ -158,6 +168,7 @@ class HtmlSanitizerAdditionalProtocolsTests(CMSTestCase):
         self.assertHTMLEqual(original, cleaned)
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class HTMLDynamicAttriutesTest(TestFixture, CMSTestCase):
     def test_dynamic_link(self):
         page = self.create_page("page", "page.html", language="en")
@@ -190,6 +201,7 @@ class HTMLDynamicAttriutesTest(TestFixture, CMSTestCase):
         )
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class DynamicAttributesTestCase(TestCase):
     @patch("djangocms_text.html.apps.get_model")
     def test_dynamic_href_sets_correct_attribute(self, mock_get_model):
@@ -235,6 +247,7 @@ def save_image(filename, image, parent_plugin, width, height):
     pass
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class DjangoCMSPictureIntegrationTestCase(CMSTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,11 +1,14 @@
 # original from
 # http://tech.octopus.energy/news/2016/01/21/testing-for-missing-migrations-in-django.html
 import io
+from unittest import skipIf
 
+from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
 
+@skipIf(settings.CMS_NOT_USED, "Skipping tests because djangocms is not installed")
 class MigrationTestCase(TestCase):
     @override_settings(MIGRATION_MODULES={})
     def test_for_missing_migrations(self):

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,14 +1,18 @@
 from unittest import skipIf
-
-from cms.api import add_plugin
-
-from djangocms_text import html, settings
-from djangocms_text.utils import plugin_to_tag
-
-from .base import BaseTestCase
 from .fixtures import TestFixture
+from .base import BaseTestCase
+
+try:
+    from cms.api import add_plugin
+    from djangocms_text import html, settings
+    from djangocms_text.utils import plugin_to_tag
+
+    SKIP_CMS_TEST = False
+except ModuleNotFoundError:
+    SKIP_CMS_TEST = True
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
 class WidgetTestCase(TestFixture, BaseTestCase):
     def setUp(self):
         self.super_user = self._create_user("test", True, True)
@@ -104,3 +108,13 @@ class WidgetTestCase(TestFixture, BaseTestCase):
         url = page.get_absolute_url(language)
         response = self.client.get(url)
         self.assertContains(response, "<span>some text</span>")
+
+
+@skipIf(not SKIP_CMS_TEST, "Skipping tests because djangocms is installed")
+class NonCMSWidgetTestCase(BaseTestCase):
+    def test_django_form_renders_widget(self):
+        from tests.test_app.forms import SimpleTextForm
+
+        form = SimpleTextForm()
+        rendered = form.render()
+        self.assertTrue(isinstance(rendered, str))

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -17,7 +17,8 @@ i18n_urls = [
     re_path(r"^admin/", admin.site.urls),
 ]
 
-i18n_urls.append(path("", include("cms.urls")))  # NOQA
+if not settings.CMS_NOT_USED:
+    i18n_urls.append(path("", include("cms.urls")))  # NOQA
 
 urlpatterns += i18n_patterns(*i18n_urls)
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
feat(tests): added test configuration for django without cms

I have added a test configuration that does not use djangocms and made the tests run in a try-except block if they need cms, not sure if there is a more elegant solution to this

fix(utils): made django Models import from django.db.models

django.db does not contain the class Models, only django.db.models does, I have verified this for django 5.2 and django 4.2

fix(depends): made django-classy-tags a dependency

This dependency is imported in djangocms_text.utils with no try/except blocks or if/else blocks, it is thus from my point of view a definite dependency of the package as the package does not render a widget without it

## Summary by Sourcery

Enable running the test suite without django-cms by making cms imports optional, correct utility imports and add missing dependency, and broaden test coverage and CI matrix for standalone Django setups

New Features:
- Allow tests to run without django-cms by conditionally wrapping cms imports and using a CMS_NOT_USED flag
- Make django-cms dependency optional in tests settings and middleware configuration

Bug Fixes:
- Fix incorrect import of Model from django.db.models instead of django.db
- Add django-classy-tags to dependencies for utils import

Enhancements:
- Expand CI test matrix to include a Django-only environment (Django 5.2 without cms)

CI:
- Update GitHub Actions to include dj52 environment

Tests:
- Restructure and extend tests under conditional cms imports
- Add coverage for HTML sanitization, dynamic attributes, plugin export/import, widget config, and plugin copy behaviors