### PR TITLE
chore: Add `THIRD_PARTY_LICENSES.txt` to published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ bundles/
 bundle.ckeditor5.min.css
 bundle.tiptap.min.css
 bundle.ckeditor4.min.css
+THIRD_PARTY_LICENSES.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "html-webpack-plugin": "^5.6.3",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
+        "license-webpack-plugin": "^4.0.2",
         "mini-css-extract-plugin": "^2.9.3",
         "npm-upgrade": "^3.1.2",
         "postcss": "^8.5.6",
@@ -11878,6 +11879,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/license-webpack-plugin": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-4.0.2.tgz",
+      "integrity": "sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "webpack-sources": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
+        "webpack-sources": {
+          "optional": true
+        }
       }
     },
     "node_modules/lilconfig": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "html-webpack-plugin": "^5.6.3",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
+    "license-webpack-plugin": "^4.0.2",
     "mini-css-extract-plugin": "^2.9.3",
     "npm-upgrade": "^3.1.2",
     "postcss": "^8.5.6",

--- a/private/license-templates/MIT.txt
+++ b/private/license-templates/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ build.include = [
 build.artifacts = [
   "djangocms_text/static/**",
   "djangocms_text/contrib/**/static/**",
+  "djangocms_text/THIRD_PARTY_LICENSES.txt",
 ]
 version.path = "djangocms_text/__init__.py"
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const { LicenseWebpackPlugin } = require('license-webpack-plugin');
 
 
 const distribution = {
@@ -23,6 +24,28 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: (pathData) => {
                 return distribution[pathData.chunk.name] + 'css/bundle.' + pathData.chunk.name + '.min.css';
+            },
+        }),
+        new LicenseWebpackPlugin({
+            outputFilename: 'THIRD_PARTY_LICENSES.txt',
+            perChunkOutput: false,
+            licenseTemplateDir: path.resolve(__dirname, 'private/license-templates'),
+            renderLicenses: (modules) => {
+                // Group packages by their license text to avoid repeating identical texts
+                const groups = {};
+                for (const mod of modules) {
+                    const text = (mod.licenseText || '').trim();
+                    if (!groups[text]) {
+                        groups[text] = { type: mod.licenseId, packages: [] };
+                    }
+                    groups[text].packages.push(mod.packageJson.name);
+                }
+                const sections = [];
+                for (const [text, { type, packages }] of Object.entries(groups)) {
+                    const heading = packages.sort().join('\n');
+                    sections.push(`${heading}\n\n${type}\n\n${text}`);
+                }
+                return sections.join('\n\n' + '='.repeat(70) + '\n\n');
             },
         }),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,13 +36,15 @@ module.exports = {
                 for (const mod of modules) {
                     const text = (mod.licenseText || '').trim();
                     if (!groups[text]) {
-                        groups[text] = { type: mod.licenseId, packages: [] };
+                        // Use a Set to avoid duplicate package names per license text
+                        groups[text] = { type: mod.licenseId, packages: new Set() };
                     }
-                    groups[text].packages.push(mod.packageJson.name);
+                    groups[text].packages.add(mod.packageJson.name);
                 }
                 const sections = [];
                 for (const [text, { type, packages }] of Object.entries(groups)) {
-                    const heading = packages.sort().join('\n');
+                    const uniquePackages = Array.from(packages).sort();
+                    const heading = uniquePackages.join('\n');
                     sections.push(`${heading}\n\n${type}\n\n${text}`);
                 }
                 return sections.join('\n\n' + '='.repeat(70) + '\n\n');


### PR DESCRIPTION
fixes #143

## Summary by Sourcery

Generate and ship a consolidated third-party license file with the built package.

Enhancements:
- Integrate LicenseWebpackPlugin into the Webpack build to emit a THIRD_PARTY_LICENSES.txt file containing third-party license texts, grouped by unique license content.
- Add a custom MIT license template for license generation.
- Ensure the generated THIRD_PARTY_LICENSES.txt file is included in the Python package build artifacts.

Build:
- Add license-webpack-plugin as a development dependency for the Webpack build pipeline.