### PR TITLE
fix: Defining `TEXT_EDITOR_SETTINGS` in settings.py removed all default settings

### DIFF
--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -143,7 +143,7 @@ class TextEditorWidget(forms.Textarea):
         self.plugin_position = plugin_position  # specific
         if configuration and getattr(settings, configuration, False):
             self.configuration = deepcopy(self.rte_config.configuration)
-            self.configuration.update(settings.TEXT_EDITOR_SETTINGS)
+            self.configuration.update(text_settings.TEXT_EDITOR_SETTINGS)
             self.configuration.update(getattr(settings, configuration))
         else:
             self.configuration = deepcopy(self.rte_config.configuration)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -110,6 +110,31 @@ class WidgetTestCase(TestFixture, BaseTestCase):
         self.assertContains(response, "<span>some text</span>")
 
 
+@skipIf(SKIP_CMS_TEST, "Skipping tests because djangocms is not installed")
+class WidgetConfigurationTestCase(BaseTestCase):
+    def test_htmlfield_configuration_without_text_editor_settings(self):
+        """Regression test for #136: HTMLField(configuration=...) should not
+        raise AttributeError when TEXT_EDITOR_SETTINGS is not in Django settings."""
+        from django.conf import settings
+        from djangocms_text.widgets import TextEditorWidget
+
+        # Ensure TEXT_EDITOR_SETTINGS is not set in Django settings
+        has_setting = hasattr(settings, "TEXT_EDITOR_SETTINGS")
+        if has_setting:
+            original = settings.TEXT_EDITOR_SETTINGS
+            delattr(settings, "TEXT_EDITOR_SETTINGS")
+
+        # Define a custom configuration in Django settings
+        settings.MY_CUSTOM_CONFIG = {"toolbar": "HTMLField"}
+        try:
+            widget = TextEditorWidget(configuration="MY_CUSTOM_CONFIG")
+            self.assertEqual(widget.configuration["toolbar"], "HTMLField")
+        finally:
+            del settings.MY_CUSTOM_CONFIG
+            if has_setting:
+                settings.TEXT_EDITOR_SETTINGS = original
+
+
 @skipIf(not SKIP_CMS_TEST, "Skipping tests because djangocms is installed")
 class NonCMSWidgetTestCase(BaseTestCase):
     def test_django_form_renders_widget(self):


### PR DESCRIPTION
fixes #136

## Summary by Sourcery

Fix HTMLField widget configuration to use the correct text editor settings source and add a regression test to cover configuration without TEXT_EDITOR_SETTINGS being defined.

Bug Fixes:
- Ensure HTMLField/TextEditorWidget configuration works correctly when TEXT_EDITOR_SETTINGS is missing from Django settings by using the appropriate text settings source instead.

Tests:
- Add a regression test verifying that TextEditorWidget can be configured via a custom Django setting even when TEXT_EDITOR_SETTINGS is not defined.