### PR TITLE
chore: Optimize test build

### DIFF
--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -29,9 +29,6 @@ jobs:
         pip install
         build django
         --user
-    - name: Compile messages
-      run: django-admin compilemessages
-      working-directory: djangocms_text
     - uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
@@ -39,6 +36,9 @@ jobs:
       run: npm install
     - name: Build client
       run: webpack --mode production
+    - name: Compile messages
+      run: django-admin compilemessages
+      working-directory: djangocms_text
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -29,9 +29,6 @@ jobs:
         pip install
         build django
         --user
-    - name: Compile messages
-      run: django-admin compilemessages
-      working-directory: djangocms_text
     - uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
@@ -39,6 +36,9 @@ jobs:
       run: npm install
     - name: Build client
       run: webpack --mode production
+    - name: Compile messages
+      run: django-admin compilemessages
+      working-directory: djangocms_text
 
     - name: Build a binary wheel and a source tarball
       run: >-
@@ -49,6 +49,9 @@ jobs:
         --outdir dist/
         .
 
+    - name: Show source dist content
+      run: >-
+        tar tzf dist/*.tar.gz
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include djangocms_text *.html *.txt *.mo *.js *.css *.svg *.png *.gif *.jpg *.woff *.woff2 *.ttf *.eot
 recursive-include djangocms_text_ckeditor *.html *.txt *.js *.css *.svg *.png *.gif *.jpg *.woff *.woff2 *.ttf *.eot
+include THIRD_PARTY_LICENSES.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include djangocms_text *.html *.txt *.mo *.js *.css *.svg *.png *.gif *.jpg *.woff *.woff2 *.ttf *.eot
+recursive-include djangocms_text_ckeditor *.html *.txt *.js *.css *.svg *.png *.gif *.jpg *.woff *.woff2 *.ttf *.eot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=64" ]
 
 [project]
 name = "djangocms-text"
@@ -55,20 +55,18 @@ dependencies = [
 urls.Homepage = "https://github.com/django-cms/djangocms-text"
 
 [tool.setuptools]
-packages = [ "djangocms_text", "djangocms_text_ckeditor" ]
-
-[tool.hatch]
-build.include = [
-  "/djangocms_text",
-  "/djangocms_text_ckeditor",
+packages.find.include = [ "djangocms_text*", "djangocms_text_ckeditor*" ]
+dynamic.version = { attr = "djangocms_text.__version__" }
+package-data."djangocms_text" = [
+  "locale/**/*.mo",
+  "static/**",
+  "contrib/**/static/**",
+  "templates/**",
+  "THIRD_PARTY_LICENSES.txt",
 ]
-build.artifacts = [
-  "djangocms_text/static/**",
-  "djangocms_text/contrib/**/static/**",
-  "djangocms_text/locale/**/*.mo",
-  "djangocms_text/THIRD_PARTY_LICENSES.txt",
+package-data."djangocms_text_ckeditor" = [
+  "static/**",
 ]
-version.path = "djangocms_text/__init__.py"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ package-data."djangocms_text" = [
   "static/**",
   "contrib/**/static/**",
   "templates/**",
-  "THIRD_PARTY_LICENSES.txt",
 ]
 package-data."djangocms_text_ckeditor" = [
   "static/**",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
             },
         }),
         new LicenseWebpackPlugin({
-            outputFilename: 'THIRD_PARTY_LICENSES.txt',
+            outputFilename: '../THIRD_PARTY_LICENSES.txt',
             perChunkOutput: false,
             licenseTemplateDir: path.resolve(__dirname, 'private/license-templates'),
             renderLicenses: (modules) => {


### PR DESCRIPTION
## Summary by Sourcery

Switch packaging and build configuration to setuptools and align CI publishing workflows with the new build artefacts.

Build:
- Change Python build backend from hatchling to setuptools and configure package discovery, dynamic versioning, and package data for Django CMS text packages.
- Add MANIFEST configuration to control which project files are included in source distributions.
- Adjust webpack license output path so generated license file is placed alongside packaged artefacts.

CI:
- Reorder message compilation in TestPyPI and PyPI publish workflows to run after the client build and add a step to list source distribution contents in the TestPyPI workflow.