### PR TITLE
fix: Toolbar z-Index, trailing paragraphs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+0.9.5 (08-04-2026)
+==================
+
+* feat: Allow inline editing with wrappers (custom `text.html` template)
+* feat: Improve performance
+* feat: Improve markdown detection on paste
+* fix: Tiptap added an empty paragraph after heading-only content
+* fix: Avoid initial scrolling in change views
+* fix: Make inline toolbar positioned absolutely and sticky using javascript
+* fix: Show cursor in empty HTMLFields
+
 0.9.4 (15-03-2026)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 * fix: Avoid initial scrolling in change views
 * fix: Make inline toolbar positioned absolutely and sticky using javascript
 * fix: Show cursor in empty HTMLFields
+* fix: Revert on cancel was called for non-editor modals
 
 0.9.4 (15-03-2026)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,24 @@ loses focus. If only text has changed the user can immediately continue to edit.
 text-enabled plugin was changed, added, or removed he page will refresh to update the
 page tree and get the correctly rendered version of the changed plugin.
 
+Custom plugin templates
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If you override the default ``cms/plugins/text.html`` template and your template wraps
+the plugin output in container elements (e.g. ``<section>``, ``<article>``, ``<div>``),
+the **innermost** container element must have the class ``cms-content-start``::
+
+    <!-- cms/plugins/text.html -->
+    <section class="my-text-plugin">
+        <div class="cms-content-start">
+            {{ body|safe }}
+        </div>
+    </section>
+
+This tells the inline editor which element to use as the editable area. Without it the
+editor will treat the outermost container as the editable region which may include
+non-editable markup.
+
 
 Text-enabled plugins
 ~~~~~~~~~~~~~~~~~~~~

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -7,6 +7,7 @@
     textarea.CMS_Editor + div#id_body_editor.fixed {
         display: flex;
         flex-flow: column;
+        position: relative;
         height: 100%;
         width: 100%;
         max-width: 100%; /* for djangocms-admin-style */

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -41,6 +41,17 @@
     position: relative;
 
     .tiptap {
+        min-height: 1em;
+
+        /* Placeholder text for empty nodes */
+        .is-empty::before {
+            content: '\00a0';
+            float: left;
+            color: var(--dca-gray, #adb5bd);
+            pointer-events: none;
+            height: 0;
+        }
+
         &.ProseMirror-focused {
             /* Safari: Only outline the editor div, not toolbar etc. */
             outline: 3px solid AccentColor;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -26,8 +26,9 @@ html.cms-toolbar-expanded {
     }
 
     .cms-toolbar-sticky {
-        position: sticky;
+        position: absolute;
         top: 0;
+        width: 100%;
         z-index: 88889; /* Above #cms-top (z-index: 88888) */
         height: 0;
         overflow: visible;
@@ -68,6 +69,7 @@ html.cms-toolbar-expanded {
     &.fixed [role="menubar"]  {
         display: block;
         top: 0;
+        z-index: unset;
         visibility: visible;
         transition: visibility var(--tiptap-ease, 100ms);
         [role="button"].show {
@@ -77,7 +79,7 @@ html.cms-toolbar-expanded {
                 height: auto;
             }
         }
-        position: sticky;
+        position: absolute;
         width: 100%;
         box-sizing: border-box;
         outline: none;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -69,8 +69,12 @@ html.cms-toolbar-expanded {
     &.fixed [role="menubar"]  {
         display: block;
         top: 0;
+        bottom: unset;
+        inset-inline-start: unset;
+        min-width: unset;
         z-index: unset;
         visibility: visible;
+        opacity: 1;
         transition: visibility var(--tiptap-ease, 100ms);
         [role="button"].show {
             z-index: 10;
@@ -79,7 +83,7 @@ html.cms-toolbar-expanded {
                 height: auto;
             }
         }
-        position: absolute;
+        position: sticky;
         width: 100%;
         box-sizing: border-box;
         outline: none;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -20,7 +20,7 @@ html.cms-toolbar-expanded {
             }
         }
     }
-    &:has(dialog.cms-form-dialog) [role="menubar"] {
+    &.has-form-dialog [role="menubar"] {
         /* show toolbar if form dialog is open */
         visibility: visible;
     }
@@ -55,7 +55,6 @@ html.cms-toolbar-expanded {
         box-shadow: 0 1.5px 1.5px rgba(var(--dca-shadow), .4);
         color: var(--dca-black, var(--body-fg));
         background: var(--dca-white, var(--body-bg));
-        opacity: 1;
 
         div.grouper {
             padding: 0;
@@ -178,7 +177,7 @@ html.cms-toolbar-expanded {
         vertical-align: middle;
         line-height: 1.2;
         padding: 6px 4px  !important;
-        &:active, &.active, &:has(.active):not(:has([data-action^="Heading"], [data-action="Paragraph"])) {
+        &:active, &.active, &.has-active-child {
             background: var(--dca-gray-lighter, var(--selected-bg))  !important;
         }
         &:hover:not(:disabled):not([data-action="TextColor"]),&.show {
@@ -310,12 +309,15 @@ html.cms-toolbar-expanded {
         z-index: -1;
         cursor: unset;  /* browser default */
     }
-    :not(:has(.dropdown.show)) .toolbar-dropback {
+    .toolbar-dropback {
         display: none;
+    }
+    .has-dropdown-open .toolbar-dropback {
+        display: block;
     }
 
     /* Block toolbar */
-    .ProseMirror-focused .cms-block-toolbar, &:has(dialog.cms-form-dialog) .cms-block-toolbar {
+    .ProseMirror-focused .cms-block-toolbar, &.has-form-dialog .cms-block-toolbar {
         /* show toolbar if editor is focused or form dialog is open */
         visibility: visible;
         opacity: 1;

--- a/private/js/cms.dialog.js
+++ b/private/js/cms.dialog.js
@@ -325,6 +325,7 @@ class CmsForm {
 
     open() {
         this.dialog.show();
+        this.el.classList.add('has-form-dialog');
         const firstInput = this.dialog.querySelector('input');
         if (firstInput) {
             firstInput.focus();
@@ -340,6 +341,7 @@ class CmsForm {
                 this.cancel(event);
             }
             this.dialog.remove();
+            this.el.classList.remove('has-form-dialog');
         }
     }
 

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -124,16 +124,20 @@ class CMSEditor {
             return;
         }
 
+        const initAsync = typeof requestIdleCallback === 'function'
+            ? (cb) => requestIdleCallback(cb, {timeout: 2000})
+            : (cb) => setTimeout(cb, 0);
+
         this.observer = this.observer || new IntersectionObserver( (entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {
                     this.observer.unobserve(entry.target);  // Only init once
-                    this.init(entry.target);
+                    initAsync(() => this.init(entry.target));
                 }
             }, this);
         }, {
             root: null,
-            threshold: 0.05
+            threshold: 0
         });
         this.observer.disconnect();
 
@@ -188,10 +192,13 @@ class CMSEditor {
                         // Only add to the observer if not already observed (e.g., if the page only was update partially)
                         this.observer.observe(wrapper);
                         if (this.CMS) {
-                            // Remove django CMS core's double click event handler which opens an edit dialog
+                            // Only suppress CMS double click if the inline editor was created
+                            // If creation fails, the default CMS modal editing should still work
                             this.CMS.$(wrapper).off('dblclick.cms.plugin')
                                 .on('dblclick.cms-editor', function (event) {
-                                    event.stopPropagation();
+                                    if (wrapper.id && wrapper.id in (window.cms_editor_plugin?._editors || {})) {
+                                        event.stopPropagation();
+                                    }
                                 });
                             wrapper.addEventListener('focusin', () => {
                                 this._highlightTextplugin(id);

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -10,6 +10,12 @@ import CmsDialog from "./cms.dialog";
 // CMS Editor
 // #############################################################################
 
+const WRAPPER_TAGS = new Set([
+    'DIV', 'SECTION', 'ARTICLE', 'MAIN', 'ASIDE',
+    'HEADER', 'FOOTER', 'NAV', 'CMS-PLUGIN',
+]);
+
+
 class CMSEditor {
 
     // CMS Editor: constructor
@@ -678,12 +684,16 @@ class CMSEditor {
 
         if (elements.length > 0) {
             if (elements.length === 1 && (
-                elements[0].tagName === 'DIV' || // Single wrapping div
-                elements[0].tagName === 'CMS-PLUGIN' ||  // Single wrapping cms-plugin tag
+                WRAPPER_TAGS.has(elements[0].tagName) ||  // Single wrapping container element
                 elements[0].classList.contains('cms-editor-inline-wrapper')  // already wrapped
             )) {
                 // already wrapped?
                 wrapper = elements[0];
+                // Check for .cms-content-start inside the plugin and use it as the editing base
+                const contentStart = wrapper.querySelector('.cms-content-start');
+                if (contentStart) {
+                    wrapper = contentStart;
+                }
                 wrapper.classList.add('cms-editor-inline-wrapper');
             } else {  // no, wrap now!
                 wrapper = document.createElement('div');

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -232,8 +232,8 @@ class CMSEditor {
             JSON.parse(el.dataset.options || '{}')
         );
 
-        // Add event listener to delete data on modal cancel
-        if (settings.revert_on_cancel) {
+        // Add event listener to delete data on modal cancel (only for modal/admin editors)
+        if (settings.revert_on_cancel && el.tagName === 'TEXTAREA') {
             const CMS = this.CMS;
             const csrf = CMS.config?.csrf || document.querySelector('input[name="csrfmiddlewaretoken"]').value;
             CMS.API.Helpers.addEventListener(

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -231,7 +231,7 @@ class CMSTipTapPlugin {
             }
 
             // Preserve scroll position: editor creation may cause unwanted scrolling
-            const scrollY = window.scrollY;
+            const scrollY = window.scrollY || 0;
             const editor = new Editor({
                 extensions: extensions,
                 autofocus: shouldAutofocus ? 'start' : false,
@@ -249,7 +249,9 @@ class CMSTipTapPlugin {
                 separator_markup: this.separator_markup,
                 space_markup: this.space_markup,
             });
-            window.scrollTo({top: scrollY});
+            if (window.scrollY !== scrollY) {
+                window.scrollTo({top: scrollY});
+            }
             editor.on('blur', ({editor, event}) => {
                 this._blurEditor(editor, event);
             });

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -142,6 +142,7 @@ class CMSTipTapPlugin {
             extensions: [
                 StarterKit.configure({
                     link: false,  // CmsDynLink replaces StarterKit's Link
+                    trailingNode: false,  // Disable auto-appended trailing paragraph after headings etc.
                 }),
                 CharacterCount,
                 Image,

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -222,15 +222,19 @@ class CMSTipTapPlugin {
             const toolbarItems = collectToolbarItems(toolbar);
             const extensions = filterExtensions(options.extensions, toolbarItems);
 
+            const firstInput = document.querySelector('textarea, input:not([type="hidden"]), select');
+            const shouldAutofocus = el.tagName === 'TEXTAREA' && firstInput === el;
             const editorElement = this._transform_textarea(el, inModal);
             if (el.tagName === 'TEXTAREA') {
                 // Fix toolbar position for non-inline editors
                 editorElement.classList.add('fixed');
             }
 
+            // Preserve scroll position: editor creation may cause unwanted scrolling
+            const scrollY = window.scrollY;
             const editor = new Editor({
                 extensions: extensions,
-                autofocus: false,
+                autofocus: shouldAutofocus ? 'start' : false,
                 content: content || '',
                 editable: true,
                 element: editorElement,
@@ -245,6 +249,7 @@ class CMSTipTapPlugin {
                 separator_markup: this.separator_markup,
                 space_markup: this.space_markup,
             });
+            window.scrollTo({top: scrollY});
             editor.on('blur', ({editor, event}) => {
                 this._blurEditor(editor, event);
             });

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -346,6 +346,9 @@ class CMSTipTapPlugin {
         // Let the editor process clicks first
         // This hopefully prevents race conditions
         setTimeout(() => {
+            if (editor.isDestroyed) {
+                return;
+            }
             // Allow toolbar and other editor widgets to process the click first
             // They need to refocus the editor to avoid a save
             const {id} = editor.options.el;

--- a/private/js/tiptap_plugins/cms.markdown.js
+++ b/private/js/tiptap_plugins/cms.markdown.js
@@ -7,28 +7,40 @@ import {Extension} from "@tiptap/core";
 import {Plugin} from "@tiptap/pm/state";
 import showdown from "showdown";
 
-// Check for typical Markdown elements
+// Weighted markdown patterns: each has a score reflecting how strong a signal it is.
+// A higher threshold reduces false positives from plain text that happens to contain
+// a single markdown-like pattern.
 const markdownPatterns = [
-    /^#{1,6}\s.+/m,         // Headings: #, ##, ...
-    /\*\*.*\*\*/m,          // Bold: **text**
-    /\*.*\*/m,              // Italic: *text*
-    /\[.*\]\(.*\)/m,        // Links: [text](url)
-    /^>\s.+/m,              // Blockquote: >
-    /^-\s.+/m,              // Lists: - item
-    /^(\d+\.)\s.+/m,        // Numbered lists: 1. item
-    /`[^`]+`/m,             // Inline-Code: `code`
-    /^```/m                 // Code blocks: ```
+    { pattern: /^#{1,6}\s.+/m,              score: 2 },  // Headings
+    { pattern: /\*\*[^\s*].*?[^\s*]\*\*/m,  score: 2 },  // Bold: **text** (non-greedy, no spaces at edges)
+    { pattern: /(?<!\*)\*[^\s*].*?[^\s*]\*(?!\*)/m, score: 1 }, // Italic: *text* (not bold)
+    { pattern: /\[[^\]]+\]\(https?:\/\/[^)]+\)/m, score: 3 },  // Links with URL
+    { pattern: /^>\s.+/m,                   score: 1 },  // Blockquote
+    { pattern: /^[-*+]\s.+/m,               score: 1 },  // Unordered list
+    { pattern: /^\d+\.\s.+/m,               score: 1 },  // Ordered list
+    { pattern: /`[^`\n]+`/m,                score: 1 },  // Inline code
+    { pattern: /^```/m,                      score: 3 },  // Code block
+    { pattern: /^---\s*$/m,                  score: 2 },  // Horizontal rule
+    { pattern: /!\[[^\]]*\]\([^)]+\)/m,      score: 3 },  // Images
 ];
+
+const MARKDOWN_THRESHOLD = 3; // Minimum score to treat as markdown
 
 const markdownAntiPatterns = [
     /on(begin|end|repeat|abort|error|resize|scroll|unload|copy|cut|paste|cancel|canplay|canplaythrough|change|click|close|cuechange|dblclick|drag|dragend|dragenter|dragleave|dragover|dragstart|drop|durationchange|emptied|ended|focus|input|invalid|keydown|keypress|keyup|load|loadeddata|loadedmetadata|loadstart|mousedown|mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|mousewheel|pause|play|playing|progress|ratechange|reset|resize|scroll|seeked|seeking|select|show|stalled|submit|suspend|timeupdate|toggle|volumechange|waiting|activate|focusin|focusout)\s*=/i,
     /base64,/i,
     /['"(]\s*javascript\s*:/i,
+    /<\w+[\s>]/,  // Contains HTML tags
 ];
 
-function isProbablyMarkdown(text) {
-    return text && markdownPatterns.some(pattern => pattern.test(text)) &&
-           !markdownAntiPatterns.some(pattern => pattern.test(text));
+export function isProbablyMarkdown(text) {
+    if (!text || markdownAntiPatterns.some(p => p.test(text))) {
+        return false;
+    }
+    const score = markdownPatterns.reduce(
+        (sum, {pattern, score: pts}) => sum + (pattern.test(text) ? pts : 0), 0
+    );
+    return score >= MARKDOWN_THRESHOLD;
 }
 
 const markdownPasteHandler = Extension.create({
@@ -41,8 +53,11 @@ const markdownPasteHandler = Extension.create({
             new Plugin({
                 props: {
                     handlePaste(view, event, slice) {
-                        // Your custom paste logic here
-                        // Example: get plain text from clipboard
+                        // Skip if clipboard already has HTML (rich paste from browser/app)
+                        const html = event.clipboardData?.getData('text/html');
+                        if (html) {
+                            return false;
+                        }
                         const text = event.clipboardData?.getData('text/plain');
                         if (isProbablyMarkdown(text)) {
                             const converter = new showdown.Converter(window.cms_editor_plugin?.markdownOptions || {

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -667,7 +667,7 @@ function _updateToolbar(editor, toolbar) {
     const SKIP_ACTIONS = new Set(['Heading1','Heading2','Heading3','Heading4','Heading5','Heading6','Paragraph']);
     const topToolbar = editor.options.topToolbar;
     if (!topToolbar) { editor.options.el.dataset.selecting = 'false'; return; }
-    for (const dropdown of topToolbar.querySelectorAll('[role="button"].dropdown')) {
+    for (const dropdown of topToolbar.querySelectorAll('.dropdown')) {
         const hasActive = Array.from(dropdown.querySelectorAll('.active'))
             .some(el => !SKIP_ACTIONS.has(el.dataset.action));
         if (hasActive !== dropdown.classList.contains('has-active-child')) {

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -306,7 +306,7 @@ function _createTopToolbarPlugin(editor, filter) {
                             const wrapper = document.createElement('div');
                             wrapper.classList.add('cms-toolbar-sticky');
                             wrapper.appendChild(topToolbar);
-                            _pinToolbarOnScroll(editor.options.element, wrapper, true);
+                            editor.options._cleanupScrollPin = _pinToolbarOnScroll(editor.options.element, wrapper, true);
                             return wrapper;
                         }
                         // Fixed toolbar: sticky positioning keeps it in view
@@ -392,6 +392,9 @@ function _pinToolbarOnScroll(editorElement, toolbar, isInline) {
     const scrollTarget = _findScrollParent(editorElement);
     scrollTarget.addEventListener('scroll', update, {passive: true});
     update();
+
+    // Return cleanup function to remove the scroll listener
+    return () => scrollTarget.removeEventListener('scroll', update);
 }
 
 /**
@@ -683,6 +686,12 @@ const CmsToolbarPlugin = Extension.create({
                 });
             }
         });
+    },
+    onDestroy() {
+        if (this.editor.options._cleanupScrollPin) {
+            this.editor.options._cleanupScrollPin();
+            delete this.editor.options._cleanupScrollPin;
+        }
     },
     addProseMirrorPlugins() {
         'use strict';

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -282,6 +282,9 @@ function _createTopToolbarPlugin(editor, filter) {
                             // Let the form handle clicks inside it
                             return false;
                         }
+                        if (!editor.isFocused) {
+                            editor.commands.focus();
+                        }
                         _handleToolbarClick(event, editor);
                         return true;
                     }
@@ -389,12 +392,27 @@ function _pinToolbarOnScroll(editorElement, toolbar, isInline) {
         }
     }
 
+    let rafId = 0;
+    function onScroll() {
+        if (!rafId) {
+            rafId = requestAnimationFrame(() => {
+                rafId = 0;
+                update();
+            });
+        }
+    }
+
     const scrollTarget = _findScrollParent(editorElement);
-    scrollTarget.addEventListener('scroll', update, {passive: true});
+    scrollTarget.addEventListener('scroll', onScroll, {passive: true});
     update();
 
     // Return cleanup function to remove the scroll listener
-    return () => scrollTarget.removeEventListener('scroll', update);
+    return () => {
+        scrollTarget.removeEventListener('scroll', onScroll);
+        if (rafId) {
+            cancelAnimationFrame(rafId);
+        }
+    };
 }
 
 /**
@@ -449,12 +467,14 @@ function _handleToolbarClick(event, editor) {
             if (!button.classList.contains('show')) {
                 _closeAllDropdowns(event, editor);
                 button.classList.add('show');
+                button.closest('[role="menubar"]')?.classList.add('has-dropdown-open');
                 content.style.top = button.offsetHeight + 'px';
                 if (button.offsetLeft + content.offsetWidth > window.innerWidth) {
                     content.style.left = (window.innerWidth - content.offsetWidth - button.offsetLeft - 25) + 'px';
                 }
             } else {
                 button.classList.remove('show');
+                button.closest('[role="menubar"]')?.classList.remove('has-dropdown-open');
             }
         } else if (TiptapToolbar[action]) {
             TiptapToolbar[action].action(editor, button);
@@ -480,6 +500,7 @@ function _closeAllDropdowns(event, editor, force) {
         .forEach((el) => {
             if (!el.contains(event.target) || force) {
                 el.classList.remove('show');
+                el.closest('[role="menubar"]')?.classList.remove('has-dropdown-open');
                 count++;
             }
         });
@@ -639,6 +660,18 @@ function _updateToolbar(editor, toolbar) {
                   console.warn(e);
                   button.remove();
               }
+        }
+    }
+    // Update parent dropdowns: mark as has-active-child if any non-heading/paragraph
+    // child is active (avoids expensive :has() CSS selector)
+    const SKIP_ACTIONS = new Set(['Heading1','Heading2','Heading3','Heading4','Heading5','Heading6','Paragraph']);
+    const topToolbar = editor.options.topToolbar;
+    if (!topToolbar) { editor.options.el.dataset.selecting = 'false'; return; }
+    for (const dropdown of topToolbar.querySelectorAll('[role="button"].dropdown')) {
+        const hasActive = Array.from(dropdown.querySelectorAll('.active'))
+            .some(el => !SKIP_ACTIONS.has(el.dataset.action));
+        if (hasActive !== dropdown.classList.contains('has-active-child')) {
+            dropdown.classList.toggle('has-active-child', hasActive);
         }
     }
     editor.options.el.dataset.selecting = 'false';

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -309,9 +309,8 @@ function _createTopToolbarPlugin(editor, filter) {
                             _pinToolbarOnScroll(editor.options.element, wrapper, true);
                             return wrapper;
                         }
-                        // Fixed toolbar: position absolutely and adjust on scroll
-                        // so it stays visible within the editor bounds
-                        _pinToolbarOnScroll(editor.options.element, topToolbar, false);
+                        // Fixed toolbar: sticky positioning keeps it in view
+                        // within the editor's scroll container
                         return topToolbar;
                     }, {
                         side: -1,

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -300,23 +300,18 @@ function _createTopToolbarPlugin(editor, filter) {
                         );
                         editor.options.topToolbar = topToolbar;
 
-                        // For inline editors: wrap in a sticky container so the
-                        // toolbar pins to the viewport top when scrolled
                         if (!editor.options.element.classList.contains('fixed')) {
+                            // For inline editors: wrap in an absolutely positioned
+                            // container and pin it on scroll
                             const wrapper = document.createElement('div');
                             wrapper.classList.add('cms-toolbar-sticky');
                             wrapper.appendChild(topToolbar);
-                            // Set top to CMS toolbar height + editor toolbar height
-                            // so the toolbar (which extends upward) lands just below the CMS toolbar
-                            const cmsToolbarHeight = parseInt(
-                                getComputedStyle(document.documentElement)
-                                    .getPropertyValue('--cms-toolbar-height') || '0', 10
-                            );
-                            requestAnimationFrame(() => {
-                                wrapper.style.top = (cmsToolbarHeight + (topToolbar.offsetHeight || 0)) + 'px';
-                            });
+                            _pinToolbarOnScroll(editor.options.element, wrapper, true);
                             return wrapper;
                         }
+                        // Fixed toolbar: position absolutely and adjust on scroll
+                        // so it stays visible within the editor bounds
+                        _pinToolbarOnScroll(editor.options.element, topToolbar, false);
                         return topToolbar;
                     }, {
                         side: -1,
@@ -328,6 +323,76 @@ function _createTopToolbarPlugin(editor, filter) {
             apply(tr, value) { return value; }
         }
     });
+}
+
+/**
+ * Keeps an absolutely positioned toolbar visible by adjusting its top offset
+ * on scroll. Repositions the toolbar so it doesn't scroll out of view,
+ * working around overflow:hidden on ancestors that would break sticky positioning.
+ *
+ * @param {HTMLElement} editorElement - The editor wrapper element.
+ * @param {HTMLElement} toolbar - The toolbar (or toolbar wrapper) element to pin.
+ */
+/**
+ * Finds the nearest scrollable ancestor of an element, or falls back to window.
+ *
+ * @param {HTMLElement} element - The element to start searching from.
+ * @returns {HTMLElement|Window} The nearest scrollable ancestor or window.
+ */
+function _findScrollParent(element) {
+    let scrollParent = element.parentElement;
+    while (scrollParent && scrollParent !== document.documentElement) {
+        const overflow = getComputedStyle(scrollParent).overflowY;
+        if (overflow === 'auto' || overflow === 'scroll') {
+            return scrollParent;
+        }
+        scrollParent = scrollParent.parentElement;
+    }
+    return window;
+}
+
+function _pinToolbarOnScroll(editorElement, toolbar, isInline) {
+    const cmsToolbarHeight = parseInt(
+        getComputedStyle(document.documentElement)
+            .getPropertyValue('--cms-toolbar-height') || '0', 10
+    );
+
+    function update() {
+        const rect = editorElement.getBoundingClientRect();
+
+        if (isInline) {
+            // Inline toolbar: the menubar extends upward from the wrapper
+            // (bottom: 100%+6px). We need to offset the wrapper down so the
+            // menubar stays visible at the CMS toolbar bottom edge.
+            const menubar = toolbar.querySelector('[role="menubar"]');
+            const menubarHeight = menubar?.offsetHeight || 0;
+            // The point where the toolbar should start pinning:
+            // editor top has scrolled above (cmsToolbarHeight + menubarHeight)
+            const pinPoint = cmsToolbarHeight + menubarHeight + 6; // 6px gap
+            if (rect.top < pinPoint) {
+                const offset = pinPoint - rect.top;
+                // Clamp so toolbar doesn't go below the editor bottom
+                const maxOffset = rect.height - menubarHeight;
+                toolbar.style.top = Math.min(offset, Math.max(0, maxOffset)) + 'px';
+            } else {
+                toolbar.style.top = '0';
+            }
+        } else {
+            // Fixed toolbar: sits at top of editor, scrolls with content
+            const toolbarHeight = toolbar.offsetHeight || 0;
+            if (rect.top < cmsToolbarHeight) {
+                const offset = cmsToolbarHeight - rect.top;
+                const maxOffset = editorElement.scrollHeight - toolbarHeight;
+                toolbar.style.top = Math.min(offset, Math.max(0, maxOffset)) + 'px';
+            } else {
+                toolbar.style.top = '0';
+            }
+        }
+    }
+
+    const scrollTarget = _findScrollParent(editorElement);
+    scrollTarget.addEventListener('scroll', update, {passive: true});
+    update();
 }
 
 /**

--- a/tests/js/cms.editor.test.js
+++ b/tests/js/cms.editor.test.js
@@ -140,7 +140,7 @@ describe('CMSEditor', () => {
     });
 
     describe('inline admin add row', () => {
-        const flush = () => new Promise(resolve => setTimeout(resolve, 10));
+        const flush = () => new Promise(resolve => setTimeout(resolve, 50));
 
         function setupInlineAdmin(inlineHTML) {
             document.body.innerHTML = `

--- a/tests/js/cms.editor.test.js
+++ b/tests/js/cms.editor.test.js
@@ -242,6 +242,137 @@ describe('CMSEditor', () => {
         });
     });
 
+    describe('_initInlineRichText', () => {
+        it('returns undefined for empty element list', () => {
+            const result = editor._initInlineRichText([], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBeUndefined();
+        });
+
+        it('uses a single DIV element as wrapper directly', () => {
+            const div = document.createElement('div');
+            div.classList.add('cms-plugin', 'cms-plugin-1');
+            document.body.appendChild(div);
+
+            const result = editor._initInlineRichText([div], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(div);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+            expect(result.dataset.cmsEditUrl).toBe('/edit/1/');
+        });
+
+        it('uses a single SECTION element as wrapper directly', () => {
+            const section = document.createElement('section');
+            section.classList.add('cms-plugin', 'cms-plugin-1');
+            document.body.appendChild(section);
+
+            const result = editor._initInlineRichText([section], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(section);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+        });
+
+        it('uses a single ARTICLE element as wrapper directly', () => {
+            const article = document.createElement('article');
+            document.body.appendChild(article);
+
+            const result = editor._initInlineRichText([article], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(article);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+        });
+
+        it('wraps a single P element in a new DIV', () => {
+            const p = document.createElement('p');
+            p.textContent = 'Hello';
+            document.body.appendChild(p);
+
+            const result = editor._initInlineRichText([p], '/edit/1/', 'cms-plugin-1');
+            expect(result.tagName).toBe('DIV');
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+            expect(result.classList.contains('wrapped')).toBe(true);
+            expect(result.contains(p)).toBe(true);
+        });
+
+        it('wraps a single H1 element in a new DIV', () => {
+            const h1 = document.createElement('h1');
+            h1.textContent = 'Title';
+            document.body.appendChild(h1);
+
+            const result = editor._initInlineRichText([h1], '/edit/1/', 'cms-plugin-1');
+            expect(result.tagName).toBe('DIV');
+            expect(result.classList.contains('wrapped')).toBe(true);
+        });
+
+        it('wraps multiple elements in a new DIV', () => {
+            const container = document.createElement('div');
+            document.body.appendChild(container);
+            const p1 = document.createElement('p');
+            const p2 = document.createElement('p');
+            p1.classList.add('cms-plugin', 'cms-plugin-1');
+            p2.classList.add('cms-plugin', 'cms-plugin-1');
+            container.appendChild(p1);
+            container.appendChild(p2);
+
+            const result = editor._initInlineRichText([p1, p2], '/edit/1/', 'cms-plugin-1');
+            expect(result.tagName).toBe('DIV');
+            expect(result.classList.contains('wrapped')).toBe(true);
+            expect(result.contains(p1)).toBe(true);
+            expect(result.contains(p2)).toBe(true);
+        });
+
+        it('uses .cms-content-start as editing base when present inside a wrapper tag', () => {
+            const div = document.createElement('div');
+            const contentStart = document.createElement('div');
+            contentStart.classList.add('cms-content-start');
+            contentStart.textContent = 'Editable content';
+            div.appendChild(contentStart);
+            document.body.appendChild(div);
+
+            const result = editor._initInlineRichText([div], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(contentStart);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+            expect(result.dataset.cmsEditUrl).toBe('/edit/1/');
+        });
+
+        it('uses .cms-content-start inside a SECTION element', () => {
+            const section = document.createElement('section');
+            const header = document.createElement('h1');
+            header.textContent = 'Title';
+            const contentStart = document.createElement('div');
+            contentStart.classList.add('cms-content-start');
+            contentStart.textContent = 'Content here';
+            section.appendChild(header);
+            section.appendChild(contentStart);
+            document.body.appendChild(section);
+
+            const result = editor._initInlineRichText([section], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(contentStart);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+        });
+
+        it('ignores .cms-content-start when element is not a wrapper tag', () => {
+            const p = document.createElement('p');
+            const span = document.createElement('span');
+            span.classList.add('cms-content-start');
+            p.appendChild(span);
+            document.body.appendChild(p);
+
+            const result = editor._initInlineRichText([p], '/edit/1/', 'cms-plugin-1');
+            // P is not a wrapper tag, so it gets wrapped in a new DIV
+            expect(result.tagName).toBe('DIV');
+            expect(result.classList.contains('wrapped')).toBe(true);
+            // The .cms-content-start check only applies to the already-wrapped case
+            expect(result).not.toBe(span);
+        });
+
+        it('falls back to wrapper when no .cms-content-start is present', () => {
+            const div = document.createElement('div');
+            div.textContent = 'Plain content';
+            document.body.appendChild(div);
+
+            const result = editor._initInlineRichText([div], '/edit/1/', 'cms-plugin-1');
+            expect(result).toBe(div);
+            expect(result.classList.contains('cms-editor-inline-wrapper')).toBe(true);
+        });
+    });
+
     describe('saveData', () => {
         let fetchMock;
 

--- a/tests/js/cms.markdown.test.js
+++ b/tests/js/cms.markdown.test.js
@@ -1,0 +1,209 @@
+/* eslint-env es11 */
+/* jshint esversion: 11 */
+
+import {isProbablyMarkdown} from '../../private/js/tiptap_plugins/cms.markdown';
+
+
+describe('isProbablyMarkdown', () => {
+    describe('should detect markdown', () => {
+        it('README-style document with heading, list, and code', () => {
+            expect(isProbablyMarkdown(
+                '# Installation\n\nRun the following:\n\n```\npip install djangocms-text\n```'
+            )).toBe(true);
+        });
+
+        it('document with heading and bold text', () => {
+            expect(isProbablyMarkdown(
+                '## Getting Started\n\nThis is **important** information.'
+            )).toBe(true);
+        });
+
+        it('document with link and heading', () => {
+            expect(isProbablyMarkdown(
+                '# Resources\n\nCheck [the docs](https://docs.example.com) for details.'
+            )).toBe(true);
+        });
+
+        it('markdown link alone (strong signal)', () => {
+            expect(isProbablyMarkdown(
+                'See [Django CMS](https://www.django-cms.org) for more info.'
+            )).toBe(true);
+        });
+
+        it('code block alone (strong signal)', () => {
+            expect(isProbablyMarkdown(
+                '```python\ndef hello():\n    print("world")\n```'
+            )).toBe(true);
+        });
+
+        it('image syntax', () => {
+            expect(isProbablyMarkdown(
+                '![Screenshot](https://example.com/screenshot.png)'
+            )).toBe(true);
+        });
+
+        it('heading with horizontal rule', () => {
+            expect(isProbablyMarkdown(
+                '# Chapter 1\n\nSome text here.\n\n---\n\n# Chapter 2'
+            )).toBe(true);
+        });
+
+        it('mixed formatting: bold, italic, inline code', () => {
+            expect(isProbablyMarkdown(
+                'Use **bold** and *italic* and `code` for formatting.'
+            )).toBe(true);
+        });
+
+        it('bullet list with multiple items and bold', () => {
+            expect(isProbablyMarkdown(
+                '- First **item**\n- Second item\n- Third item'
+            )).toBe(true);
+        });
+
+        it('numbered list with heading', () => {
+            expect(isProbablyMarkdown(
+                '## Steps\n\n1. Clone the repo\n2. Run install\n3. Start the server'
+            )).toBe(true);
+        });
+
+        it('blockquote with bold text', () => {
+            expect(isProbablyMarkdown(
+                '> **Note:** This is an important warning.\n> Please read carefully.'
+            )).toBe(true);
+        });
+    });
+
+    describe('should reject plain text (false positives)', () => {
+        it('simple sentence', () => {
+            expect(isProbablyMarkdown(
+                'This is just a normal sentence without any formatting.'
+            )).toBe(false);
+        });
+
+        it('sentence with asterisks in multiplication', () => {
+            expect(isProbablyMarkdown(
+                'The result is 3 * 4 * 5 = 60.'
+            )).toBe(false);
+        });
+
+        it('sentence with a dash that looks like a list', () => {
+            expect(isProbablyMarkdown(
+                '- but I disagree with that assessment.'
+            )).toBe(false);
+        });
+
+        it('numbered sentence', () => {
+            expect(isProbablyMarkdown(
+                '1. FC Bayern won the match yesterday.'
+            )).toBe(false);
+        });
+
+        it('email-style quoted reply', () => {
+            expect(isProbablyMarkdown(
+                '> Thanks for the update.\n> I will review it tomorrow.'
+            )).toBe(false);
+        });
+
+        it('CSS code snippet', () => {
+            expect(isProbablyMarkdown(
+                '.container { margin: 0 auto; }\n* { box-sizing: border-box; }'
+            )).toBe(false);
+        });
+
+        it('shell command with hash comment', () => {
+            expect(isProbablyMarkdown(
+                '#!/bin/bash\necho "hello world"'
+            )).toBe(false);
+        });
+
+        it('plain URL without markdown link syntax', () => {
+            expect(isProbablyMarkdown(
+                'Visit https://www.example.com for more details.'
+            )).toBe(false);
+        });
+
+        it('text with backticks in a casual context', () => {
+            expect(isProbablyMarkdown(
+                'He said `hello` and left.'
+            )).toBe(false);
+        });
+
+        it('YAML-like content', () => {
+            expect(isProbablyMarkdown(
+                'name: my-project\nversion: 1.0\ndependencies:\n  - django\n  - celery'
+            )).toBe(false);
+        });
+
+        it('Python f-string with asterisks', () => {
+            expect(isProbablyMarkdown(
+                'result = f"The answer is {a * b}"'
+            )).toBe(false);
+        });
+
+        it('multiple paragraphs of plain text', () => {
+            expect(isProbablyMarkdown(
+                'The quick brown fox jumps over the lazy dog.\n\nPack my box with five dozen liquor jugs.\n\nHow vexingly quick daft zebras jump.'
+            )).toBe(false);
+        });
+    });
+
+    describe('should reject dangerous content (anti-patterns)', () => {
+        it('HTML with event handler', () => {
+            expect(isProbablyMarkdown(
+                '# Title\n\n<div onclick="alert(1)">**click me**</div>'
+            )).toBe(false);
+        });
+
+        it('base64 encoded content', () => {
+            expect(isProbablyMarkdown(
+                '# Image\n\n![img](data:image/png;base64,iVBORw0KGgo=)'
+            )).toBe(false);
+        });
+
+        it('javascript: URL', () => {
+            expect(isProbablyMarkdown(
+                '[click me](javascript:alert(1))'
+            )).toBe(false);
+        });
+
+        it('HTML tags in text', () => {
+            expect(isProbablyMarkdown(
+                '<p>This is **bold** in HTML</p>'
+            )).toBe(false);
+        });
+
+        it('script tag', () => {
+            expect(isProbablyMarkdown(
+                '# Title\n\n<script>alert("xss")</script>'
+            )).toBe(false);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('empty string', () => {
+            expect(isProbablyMarkdown('')).toBe(false);
+        });
+
+        it('null', () => {
+            expect(isProbablyMarkdown(null)).toBe(false);
+        });
+
+        it('undefined', () => {
+            expect(isProbablyMarkdown(undefined)).toBe(false);
+        });
+
+        it('whitespace only', () => {
+            expect(isProbablyMarkdown('   \n\n  ')).toBe(false);
+        });
+
+        it('single heading without other content', () => {
+            // score 2, below threshold of 3
+            expect(isProbablyMarkdown('# Just a heading')).toBe(false);
+        });
+
+        it('single bold word without other signals', () => {
+            // score 2, below threshold
+            expect(isProbablyMarkdown('This is **bold**.')).toBe(false);
+        });
+    });
+});

--- a/tests/js/cms.styles.test.js
+++ b/tests/js/cms.styles.test.js
@@ -431,4 +431,50 @@ describe('Tiptap style extensions', () => {
             expect(html).toContain('underline');
         });
     });
+
+    describe('Document schema', () => {
+        it('does not add an empty paragraph after a heading-only document', () => {
+            const editor = createEditorWithContent('test-heading-only', '<h1>Title</h1>', {
+                toolbar: [['Heading1']],
+            });
+
+            const html = editor.getHTML();
+            expect(html).toContain('<h1>');
+            expect(html).not.toContain('<p>');
+        });
+
+        it('does not add an empty paragraph after a heading at the end', () => {
+            const editor = createEditorWithContent('test-heading-end', '<p>Text</p><h2>Title</h2>', {
+                toolbar: [['Heading2']],
+            });
+
+            const html = editor.getHTML();
+            expect(html).toContain('<h2>');
+            expect(html).toContain('<p>Text</p>');
+            // Should not have a trailing empty paragraph
+            expect(html).not.toMatch(/<\/h2>\s*<p>\s*<\/p>/);
+        });
+
+        it('preserves existing paragraphs alongside headings', () => {
+            const editor = createEditorWithContent('test-heading-para', '<h1>Title</h1><p>Body text</p>', {
+                toolbar: [['Heading1']],
+            });
+
+            const html = editor.getHTML();
+            expect(html).toContain('<h1>Title</h1>');
+            expect(html).toContain('<p>Body text</p>');
+        });
+
+        it('trailingNode is disabled so no paragraph is appended after a heading', () => {
+            const editor = createEditorWithContent('test-no-trailing', '<h1>Title</h1>', {
+                toolbar: [['Heading1']],
+            });
+
+            // After a tick, trailingNode would have appended a paragraph if enabled
+            const html = editor.getHTML();
+            expect(html).toBe('<h1>Title</h1>');
+            expect(editor.state.doc.childCount).toBe(1);
+            expect(editor.state.doc.child(0).type.name).toBe('heading');
+        });
+    });
 });


### PR DESCRIPTION
## Summary by Sourcery

Adjust toolbar positioning and editor behavior to fix z-index issues and avoid unwanted trailing paragraphs in inline and fixed editors.

Bug Fixes:
- Prevent the editor schema from appending an empty trailing paragraph after headings.
- Ensure the Tiptap toolbar remains visible with correct stacking order and positioning in both inline and fixed modes.
- Handle inline rich text wrappers more robustly, including semantic container tags and optional .cms-content-start markers.

Enhancements:
- Extend inline editor wrapper detection to support additional semantic container elements.
- Add scroll-aware toolbar pinning logic that works around overflow constraints by manually adjusting absolute positioning.

Tests:
- Add unit tests for inline rich text wrapper initialization, including wrapper tags and .cms-content-start handling.
- Add document schema tests to assert no trailing empty paragraphs are added after headings.