### PR TITLE
fix: Memory leak when updating inline editors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.9.6 (09-04-2026)
+==================
+
+* fix: Memory leak when updating inline editors
+
 0.9.5 (08-04-2026)
 ==================
 

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -36,12 +36,14 @@
         padding-top: 0;
         resize: vertical;
         overflow-y: auto;
+        contain: none; /* Fixed toolbar uses sticky inside tiptap */
     }
 
     position: relative;
 
     .tiptap {
         min-height: 1em;
+        contain: layout style;
 
         /* Placeholder text for empty nodes */
         .is-empty::before {

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -29,7 +29,21 @@
         border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
         padding: 6px;
         min-height: 3rem;
-        border-radius: 3px;
+        border-radius: 0 0 4px 4px;
+    }
+    &.textarea > [role="menubar"] {
+        border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
+        border-bottom: none;
+        border-radius: 4px 4px 0 0;
+    }
+    /* Focus outline encompasses both toolbar and editor content */
+    &.textarea:has(.ProseMirror-focused) {
+        border-radius: 4px;
+        box-shadow: 0 0 0 3px AccentColor;
+    }
+    /* Hide the inner outline on .tiptap when wrapper has the outline */
+    &.textarea .tiptap.ProseMirror-focused {
+        outline: none;
     }
 
     &.textarea.fixed .tiptap {

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -13,13 +13,14 @@ html.cms-toolbar-expanded {
         visibility: visible;
         opacity: 1;
         transition: opacity var(--tiptap-ease, 100ms) ease-in;
-        [role="button"].show {
-            z-index: 10;
-            > .dropdown-content {
-                visibility: visible;
-                opacity: 1;
-                transition: opacity var(--tiptap-ease, 100ms) ease-in;
-            }
+    }
+    /* Dropdowns inside any toolbar (visible or fixed) */
+    [role="menubar"] [role="button"].show {
+        z-index: 10;
+        > .dropdown-content {
+            visibility: visible;
+            opacity: 1;
+            transition: opacity var(--tiptap-ease, 100ms) ease-in;
         }
     }
 
@@ -59,7 +60,7 @@ html.cms-toolbar-expanded {
         bottom: unset;
         inset-inline-start: unset;
         min-width: unset;
-        z-index: unset;
+        z-index: 2;
         visibility: visible;
         opacity: 1;
         transition: visibility var(--tiptap-ease, 100ms);
@@ -226,8 +227,6 @@ html.cms-toolbar-expanded {
         border-radius: 0;
         visibility: hidden;
         opacity: 0;
-        contain: layout style;
-        /* height: 0; */
         transition: opacity var(--tiptap-ease, 100ms) ease-out,
                     visibility 0s linear var(--tiptap-ease, 100ms);
         overflow-y: hidden;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -75,12 +75,7 @@ html.cms-toolbar-expanded {
         width: 100%;
         box-sizing: border-box;
         outline: none;
-        border-bottom: 1px solid var(--dca-gray-lighter, var(--hairline-color));
-        border-top: none;
-        border-left: none;
-        border-right: none;
         box-shadow: none;
-        margin-bottom: 0.5rem  !important;
         padding-left: 0;
         padding-right: 0;
         .dropdown-content {

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -3,10 +3,13 @@ html.cms-toolbar-expanded {
     --cms-toolbar-height: 46px;
 }
 
+
 .cms-editor-inline-wrapper {
     --tiptap-ease: 100ms;
-    .ProseMirror-focused [role="menubar"] {
-        /* show toolbar if editor is focused */
+    .ProseMirror-focused [role="menubar"],
+    &.has-form-dialog [role="menubar"],
+    &.has-focused-editor [role="menubar"] {
+        /* show toolbar if editor is focused or form dialog is open */
         visibility: visible;
         opacity: 1;
         transition: opacity var(--tiptap-ease, 100ms) ease-in;
@@ -16,13 +19,8 @@ html.cms-toolbar-expanded {
                 visibility: visible;
                 opacity: 1;
                 transition: opacity var(--tiptap-ease, 100ms) ease-in;
-                /* height: auto; */
             }
         }
-    }
-    &.has-form-dialog [role="menubar"] {
-        /* show toolbar if form dialog is open */
-        visibility: visible;
     }
 
     [role="menubar"] {

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -25,19 +25,8 @@ html.cms-toolbar-expanded {
         visibility: visible;
     }
 
-    .cms-toolbar-sticky {
-        position: absolute;
-        top: 0;
-        width: 100%;
-        z-index: 88889; /* Above #cms-top (z-index: 88888) */
-        height: 0;
-        overflow: visible;
-    }
-
     [role="menubar"] {
         font-family: var(--font-family-primary, Helvetica, Arial, sans-serif);
-        bottom: calc(100% + 6px);
-        inset-inline-start: -4px;
         min-width: 375px;
         z-index: 88889; /* Above #cms-top (z-index: 88888) */
         padding: 2px 0.4rem;
@@ -47,7 +36,7 @@ html.cms-toolbar-expanded {
         visibility: hidden;
         opacity: 0;
         transition: opacity var(--tiptap-ease, 100ms) ease-out, visibility 0s linear var(--tiptap-ease, 100ms);
-        position: absolute;
+        position: fixed;
         pointer-events: all;
         display: flex;
         flex-flow: row wrap;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -44,6 +44,7 @@ html.cms-toolbar-expanded {
         box-shadow: 0 1.5px 1.5px rgba(var(--dca-shadow), .4);
         color: var(--dca-black, var(--body-fg));
         background: var(--dca-white, var(--body-bg));
+        will-change: transform;
 
         div.grouper {
             padding: 0;
@@ -227,6 +228,7 @@ html.cms-toolbar-expanded {
         border-radius: 0;
         visibility: hidden;
         opacity: 0;
+        contain: layout style;
         /* height: 0; */
         transition: opacity var(--tiptap-ease, 100ms) ease-out,
                     visibility 0s linear var(--tiptap-ease, 100ms);

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -203,12 +203,16 @@ class CMSEditor {
                             wrapper.addEventListener('focusin', () => {
                                 this._highlightTextplugin(id);
                             }, true);
-                            // Prevent tooltip on hover
-                            this.CMS.$(wrapper).off('pointerover.cms.plugin pointerout.cms.plugin')
-                                .on('pointerover.cms-editor', function (event) {
-                                    window.CMS.API.Tooltip.displayToggle(false, event.target, '', id);
-                                    event.stopPropagation();
-                                });
+                            // Prevent CMS tooltip on hover: stop pointer events from
+                            // reaching the document-level CMS delegate handler
+                            this.CMS.$(wrapper).off('pointerover.cms.plugin pointerout.cms.plugin');
+                            wrapper.addEventListener('pointerover', function (event) {
+                                event.stopPropagation();
+                                window.CMS.API.Tooltip.displayToggle(false, event.target, '', id);
+                            }, false);
+                            wrapper.addEventListener('pointerout', function (event) {
+                                event.stopPropagation();
+                            }, false);
                         }
                     }
                 }

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -642,6 +642,17 @@ class CMSEditor {
 
     // CMS Editor: resetInlineEditors
     _resetInlineEditors () {
+        // Destroy editors whose DOM elements are no longer in the document
+        // (e.g., after CMS replaces plugin HTML on save)
+        const plugin = window.cms_editor_plugin;
+        if (plugin && plugin._editors) {
+            for (const id of Object.keys(plugin._editors)) {
+                const editorElement = plugin._editors[id].options.element;
+                if (!editorElement || !document.contains(editorElement)) {
+                    plugin.destroyEditor(id);
+                }
+            }
+        }
         this.initInlineEditors();
     }
 

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -653,6 +653,14 @@ class CMSEditor {
                 }
             }
         }
+        // Clean up orphaned plain text editors
+        for (const id of Object.keys(this._generic_editors)) {
+            const el = this._generic_editors[id].el;
+            if (!el || !document.contains(el)) {
+                this._generic_editors[id].destroy();
+                delete this._generic_editors[id];
+            }
+        }
         this.initInlineEditors();
     }
 

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -651,7 +651,12 @@ class CMSEditor {
         const plugin = window.cms_editor_plugin;
         if (plugin && plugin._editors) {
             for (const id of Object.keys(plugin._editors)) {
-                const editorElement = plugin._editors[id].options.element;
+                const editorInstance = plugin._editors[id];
+                if (!editorInstance || !editorInstance.options) {
+                    delete plugin._editors[id];
+                    continue;
+                }
+                const editorElement = editorInstance.options.element;
                 if (!editorElement || !document.contains(editorElement)) {
                     plugin.destroyEditor(id);
                 }

--- a/private/js/cms.texteditor.js
+++ b/private/js/cms.texteditor.js
@@ -15,8 +15,8 @@ class CmsTextEditor {
     }
 
     destroy () {
-        this.el.removeEventListener('focus', this._focus.bind(this));
-        this.el.removeEventListener('blur', this._blur.bind(this));
+        this.el.removeEventListener('focus', this._boundFocus);
+        this.el.removeEventListener('blur', this._boundBlur);
         this.el.removeEventListener('input', this._change);
         this.el.removeEventListener('keydown', this._key_down);
         this.el.removeEventListener('paste', this._paste);
@@ -31,9 +31,12 @@ class CmsTextEditor {
 
         }
         this.el.setAttribute('spellcheck', this.options.spellcheck || 'false');
+        // Bind once and store references for proper removal in destroy()
+        this._boundFocus = this._focus.bind(this);
+        this._boundBlur = this._blur.bind(this);
         this.el.addEventListener('input', this._change);
-        this.el.addEventListener('focus', this._focus.bind(this));
-        this.el.addEventListener('blur', this._blur.bind(this));
+        this.el.addEventListener('focus', this._boundFocus);
+        this.el.addEventListener('blur', this._boundBlur);
         this.el.addEventListener('keydown', this._key_down);
         if (this.options.enforcePlaintext) {
             this.el.addEventListener('paste', this._paste);

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -257,15 +257,35 @@ class CMSTipTapPlugin {
             });
             editor.on('update', ({editor}) => {
                 el.dataset.changed = 'true';
+                // Clear textarea on first change to trigger Django's change detection
+                // Actual content is synced on form submit
                 if (el.dataset.textarea) {
-                    document.getElementById(el.dataset.textarea).value = editor.getHTML();
+                    const textarea = document.getElementById(el.dataset.textarea);
+                    if (textarea && textarea.value !== '') {
+                        textarea.value = '';
+                    }
                 }
                 if (el.dataset.jsonField) {
-                    document.getElementById(el.dataset.jsonField).value = JSON.stringify(
-                        editor.getJSON()
-                    );
+                    const jsonField = document.getElementById(el.dataset.jsonField);
+                    if (jsonField && jsonField.value !== '') {
+                        jsonField.value = '';
+                    }
                 }
             });
+            // Sync editor content to form fields on submit
+            const form = el.closest('form') || editorElement.closest('form');
+            if (form) {
+                form.addEventListener('submit', () => {
+                    if (el.dataset.textarea) {
+                        document.getElementById(el.dataset.textarea).value = editor.getHTML();
+                    }
+                    if (el.dataset.jsonField) {
+                        document.getElementById(el.dataset.jsonField).value = JSON.stringify(
+                            editor.getJSON()
+                        );
+                    }
+                });
+            }
             this._editors[el.id] = editor;
             editor.cmsPlugin = this;
 

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -277,14 +277,14 @@ class CMSTipTapPlugin {
             if (form) {
                 form.addEventListener('submit', () => {
                     if (el.dataset.textarea) {
-                        document.getElementById(el.dataset.textarea).value = editor.getHTML();
+                        const textarea = document.getElementById(el.dataset.textarea);
+                        if (textarea) textarea.value = editor.getHTML();
                     }
                     if (el.dataset.jsonField) {
-                        document.getElementById(el.dataset.jsonField).value = JSON.stringify(
-                            editor.getJSON()
-                        );
+                        const jsonField = document.getElementById(el.dataset.jsonField);
+                        if (jsonField) jsonField.value = JSON.stringify(editor.getJSON());
                     }
-                });
+                }, { once: true });
             }
             this._editors[el.id] = editor;
             editor.cmsPlugin = this;

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -708,10 +708,11 @@ const CmsToolbarPlugin = Extension.create({
     onCreate() {
         const editor = this.editor;
         const hasBlockToolbar = editor.options.blockToolbar;
+        let rafId = 0;
         editor.on('transaction', () => {
-            if (!_topToolbarRafId) {
-                _topToolbarRafId = requestAnimationFrame(() => {
-                    _topToolbarRafId = 0;
+            if (!rafId) {
+                rafId = requestAnimationFrame(() => {
+                    rafId = 0;
                     _updateToolbar(editor);
                     if (hasBlockToolbar) {
                         updateBlockToolbar(editor);

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -774,7 +774,7 @@ const CmsToolbarPlugin = Extension.create({
         let lastFrom = -1;
         let lastTo = -1;
         let toolbarRafId = 0;
-        editor.on('transaction', () => {
+        editor.on('transaction', ({transaction}) => {
             // Skip if tab is hidden
             if (document.hidden) {
                 return;
@@ -783,10 +783,12 @@ const CmsToolbarPlugin = Extension.create({
             if (!editor.isFocused && !editor.options.element.classList.contains('fixed')) {
                 return;
             }
-            // Skip if selection hasn't changed (typing at same position
-            // doesn't change active/enabled states)
+            // Skip if neither selection nor document changed.
+            // (Pure typing within the same block changes the doc but
+            // we still want to update active states; toolbar transformations
+            // like heading level changes change docChanged but keep selection.)
             const {from, to} = editor.state.selection;
-            if (from === lastFrom && to === lastTo) {
+            if (from === lastFrom && to === lastTo && !transaction.docChanged) {
                 return;
             }
             lastFrom = from;

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -322,11 +322,9 @@ function _initTopToolbar(editor, filter) {
         });
         editor.options._toolbarHost = toolbarHost;
     } else {
-        // Fixed editors: prepend to tiptap element for sticky positioning
-        const tiptap = editor.options.element.querySelector('.tiptap');
-        if (tiptap) {
-            tiptap.prepend(topToolbar);
-        }
+        // Fixed editors: prepend to the editor container so the toolbar
+        // sits above the .tiptap content area
+        editor.options.element.prepend(topToolbar);
     }
 
     // Prevent toolbar clicks from blurring the editor
@@ -660,12 +658,19 @@ function _updateToolbar(editor, toolbar) {
     'use strict';
     let buttons;
     if (!toolbar) {
-        // Cache button list on the editor element to avoid querySelectorAll on every update
+        // Cache button list to avoid querySelectorAll on every update.
+        // The top toolbar may live in document.body (inline editors), so query it
+        // directly along with the block toolbar inside the editor.
         if (!editor.options._cachedToolbarButtons) {
-            editor.options._cachedToolbarButtons = editor.options.element.querySelectorAll(
-                '.cms-toolbar button, .cms-toolbar [role="button"], ' +
-                '.cms-block-toolbar button, .cms-block-toolbar [role="button"]'
-            );
+            const fromTop = editor.options.topToolbar
+                ? Array.from(editor.options.topToolbar.querySelectorAll('button, [role="button"]'))
+                : [];
+            const fromBlock = editor.options.element
+                ? Array.from(editor.options.element.querySelectorAll(
+                    '.cms-block-toolbar button, .cms-block-toolbar [role="button"]'
+                ))
+                : [];
+            editor.options._cachedToolbarButtons = [...fromTop, ...fromBlock];
         }
         buttons = editor.options._cachedToolbarButtons;
     } else {
@@ -751,6 +756,13 @@ const CmsToolbarPlugin = Extension.create({
 
         // Create toolbar outside ProseMirror's decoration system
         _initTopToolbar(editor, filter);
+        // Set initial button states (disabled/active) once on creation
+        requestAnimationFrame(() => {
+            _updateToolbar(editor);
+            if (hasBlockToolbar) {
+                updateBlockToolbar(editor);
+            }
+        });
 
         let lastFrom = -1;
         let lastTo = -1;

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -343,34 +343,44 @@ function _positionFixedToolbar(editorElement, toolbar) {
             .getPropertyValue('--cms-toolbar-height') || '0', 10
     );
 
+    // Cache toolbar height — only changes on window resize
+    let toolbarHeight = 0;
+    // Set initial fixed position at 0,0; use transform for fast compositor updates
+    toolbar.style.top = '0';
+    toolbar.style.left = '0';
+    toolbar.style.willChange = 'transform';
+
     function update() {
         const rect = editorElement.getBoundingClientRect();
-        const toolbarHeight = toolbar.offsetHeight || 0;
 
         // Position toolbar above the editor, or pin to CMS toolbar bottom
         const idealTop = rect.top - toolbarHeight - 6;
         const minTop = cmsToolbarHeight;
         // Hide if editor is scrolled out of view
-        const editorBottom = rect.bottom;
-        if (editorBottom < cmsToolbarHeight + toolbarHeight || rect.top > window.innerHeight) {
-            toolbar.style.top = '-9999px';
+        if (rect.bottom < cmsToolbarHeight + toolbarHeight || rect.top > window.innerHeight) {
+            toolbar.style.transform = 'translate(-9999px, -9999px)';
         } else {
-            toolbar.style.top = Math.max(idealTop, minTop) + 'px';
+            const top = Math.max(idealTop, minTop);
+            toolbar.style.transform = `translate(${rect.left}px, ${top}px)`;
         }
-        toolbar.style.left = rect.left + 'px';
+    }
+
+    function onResize() {
+        toolbarHeight = toolbar.offsetHeight || 0;
+        update();
     }
 
     const scrollTarget = _findScrollParent(editorElement);
-    // No RAF debounce: updating top/left on a fixed element is cheap
-    // and avoids the one-frame lag that makes the toolbar visibly trail
     scrollTarget.addEventListener('scroll', update, {passive: true});
     window.addEventListener('scroll', update, {passive: true});
+    window.addEventListener('resize', onResize, {passive: true});
     // Defer initial positioning so the toolbar has been rendered and has a height
-    requestAnimationFrame(update);
+    requestAnimationFrame(onResize);
 
     return () => {
         scrollTarget.removeEventListener('scroll', update);
         window.removeEventListener('scroll', update);
+        window.removeEventListener('resize', onResize);
     };
 }
 
@@ -601,16 +611,20 @@ function _createToolbarButton(editor, itemName, filter) {
  */
 function _updateToolbar(editor, toolbar) {
     'use strict';
-    let querySelector;
+    let buttons;
     if (!toolbar) {
-        querySelector = editor.options.element.querySelectorAll(
-            '.cms-toolbar button, .cms-toolbar [role="button"], ' +
-            '.cms-block-toolbar button, .cms-block-toolbar [role="button"]'
-        );
+        // Cache button list on the editor element to avoid querySelectorAll on every update
+        if (!editor.options._cachedToolbarButtons) {
+            editor.options._cachedToolbarButtons = editor.options.element.querySelectorAll(
+                '.cms-toolbar button, .cms-toolbar [role="button"], ' +
+                '.cms-block-toolbar button, .cms-block-toolbar [role="button"]'
+            );
+        }
+        buttons = editor.options._cachedToolbarButtons;
     } else {
-        querySelector = toolbar.querySelectorAll('button, [role="button"]');
+        buttons = toolbar.querySelectorAll('button, [role="button"]');
     }
-    for (const button of querySelector) {
+    for (const button of buttons) {
         const {action} = button.dataset;
         if (TiptapToolbar[action]) {
               // Cache representation lookup on the button element
@@ -684,16 +698,28 @@ const CmsToolbarPlugin = Extension.create({
     onCreate() {
         const editor = this.editor;
         const hasBlockToolbar = editor.options.blockToolbar;
-        let rafId = 0;
+        let lastFrom = -1;
+        let lastTo = -1;
         editor.on('transaction', () => {
-            if (!rafId) {
-                rafId = requestAnimationFrame(() => {
-                    rafId = 0;
-                    _updateToolbar(editor);
-                    if (hasBlockToolbar) {
-                        updateBlockToolbar(editor);
-                    }
-                });
+            // Skip if tab is hidden
+            if (document.hidden) {
+                return;
+            }
+            // Skip if toolbar is not visible (inline editor not focused)
+            if (!editor.isFocused && !editor.options.element.classList.contains('fixed')) {
+                return;
+            }
+            // Skip if selection hasn't changed (typing at same position
+            // doesn't change active/enabled states)
+            const {from, to} = editor.state.selection;
+            if (from === lastFrom && to === lastTo) {
+                return;
+            }
+            lastFrom = from;
+            lastTo = to;
+            _updateToolbar(editor);
+            if (hasBlockToolbar) {
+                updateBlockToolbar(editor);
             }
         });
     },

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -160,29 +160,52 @@ function _createBlockToolbar(editor, blockToolbar) {
  */
 function updateBlockToolbar(editor, state) {
     'use strict';
+    // Skip if block toolbar isn't focused/visible
+    if (!editor.isFocused) {
+        return;
+    }
+    const blockToolbar = editor.options.blockToolbar;
     const {resolvedPos, depth} = _getResolvedPos(state || editor.state);
     if (depth > 0) {
-        _updateToolbarIcon(editor, resolvedPos.node(depth), depth > 1 ? resolvedPos.node(depth - 1) : null);
         const startPos = resolvedPos.start(depth);
-        editor.options.blockToolbar.dataset.start = startPos;
-        editor.options.blockToolbar.dataset.end = startPos + resolvedPos.node(depth).nodeSize;
-        editor.options.blockToolbar.dataset.depth = depth;
+        const node = resolvedPos.node(depth);
+        const parentNode = depth > 1 ? resolvedPos.node(depth - 1) : null;
+        // Skip DOM updates if the block hasn't changed (cursor moved within same block,
+        // and the block's identity is unchanged)
+        if (
+            blockToolbar._lastStartPos === startPos &&
+            blockToolbar._lastDepth === depth &&
+            blockToolbar._lastNode === node
+        ) {
+            return;
+        }
+        blockToolbar._lastStartPos = startPos;
+        blockToolbar._lastDepth = depth;
+        blockToolbar._lastNode = node;
+        _updateToolbarIcon(editor, node, parentNode);
+        blockToolbar.dataset.start = startPos;
+        blockToolbar.dataset.end = startPos + resolvedPos.node(depth).nodeSize;
+        blockToolbar.dataset.depth = depth;
         const pos = editor.view.coordsAtPos(startPos);
         const ref = editor.options.el.getBoundingClientRect();
-        editor.options.blockToolbar.draggable = resolvedPos.node(depth).content.size > 0;
-        editor.options.blockToolbar.style.insetBlockStart = `${pos.top - ref.top}px`;
+        blockToolbar.draggable = resolvedPos.node(depth).content.size > 0;
+        blockToolbar.style.insetBlockStart = `${pos.top - ref.top}px`;
         let title = resolvedPos.node(1)?.type.name;
-        for (let i= 2; i <= depth; i++) {
+        for (let i = 2; i <= depth; i++) {
             title += ` > ${resolvedPos.node(i)?.type.name}`;
         }
-        editor.options.blockToolbar.title = title;
+        blockToolbar.title = title;
     } else {
-        editor.options.blockToolbar.draggable = false;
-        editor.options.blockToolbar._lastIconType = null;
-        _replaceIcon(editor.options.blockToolbar.firstElementChild, _menu_icon);
+        if (blockToolbar._lastDepth === 0) {
+            return;
+        }
+        blockToolbar._lastDepth = 0;
+        blockToolbar._lastStartPos = -1;
+        blockToolbar._lastNode = null;
+        blockToolbar.draggable = false;
+        blockToolbar._lastIconType = null;
+        _replaceIcon(blockToolbar.firstElementChild, _menu_icon);
     }
-    // TODO: Set the size of the balloon according to the fontsize
-    // this.toolbar.style.setProperty('--size', this.editor.view. ...)
 }
 
 function _getResolvedPos(state) {
@@ -259,70 +282,86 @@ function _replaceIcon(node, string) {
  * @param {Function} filter - A filter function to customize the toolbar.
  * @returns {Plugin} - A ProseMirror plugin instance.
  */
+/**
+ * Creates the top toolbar DOM element and attaches it outside the ProseMirror
+ * decoration system to avoid unnecessary redraws on every transaction.
+ *
+ * For inline editors: appended to document.body with position:fixed positioning.
+ * For fixed editors: prepended to the tiptap element with sticky positioning.
+ *
+ * @param {Editor} editor - The editor instance.
+ * @param {Function} filter - A filter function to customize the toolbar.
+ */
+function _initTopToolbar(editor, filter) {
+    const topToolbar = _createToolbar(editor, editor.options.toolbar, filter);
+    editor.options.topToolbar = topToolbar;
+
+    const isFixed = editor.options.element.classList.contains('fixed');
+
+    if (!isFixed) {
+        // Inline editors: append to body to escape overflow clipping
+        // and allow CSS contain:layout on the editor.
+        // Wrap in a container with .cms-editor-inline-wrapper so toolbar CSS applies.
+        const toolbarHost = document.createElement('div');
+        toolbarHost.classList.add('cms-editor-inline-wrapper');
+        toolbarHost.appendChild(topToolbar);
+        document.body.appendChild(toolbarHost);
+        editor.options._cleanupScrollPin = _positionFixedToolbar(
+            editor.options.element, topToolbar
+        );
+        // Toggle visibility on focus/blur since toolbar is outside the editor DOM
+        editor.on('focus', () => toolbarHost.classList.add('has-focused-editor'));
+        editor.on('blur', () => {
+            // Delay hiding so toolbar clicks can be processed first
+            // (mousedown preventDefault keeps focus but blur fires first)
+            setTimeout(() => {
+                if (!editor.isFocused && !topToolbar.contains(document.activeElement)) {
+                    toolbarHost.classList.remove('has-focused-editor');
+                }
+            }, 200);
+        });
+        editor.options._toolbarHost = toolbarHost;
+    } else {
+        // Fixed editors: prepend to tiptap element for sticky positioning
+        const tiptap = editor.options.element.querySelector('.tiptap');
+        if (tiptap) {
+            tiptap.prepend(topToolbar);
+        }
+    }
+
+    // Prevent toolbar clicks from blurring the editor
+    topToolbar.addEventListener('mousedown', (e) => {
+        const form = e.target.closest('form.cms-inline-form');
+        if (!form) {
+            e.preventDefault();
+        }
+    });
+    // Handle toolbar clicks
+    topToolbar.addEventListener('click', (e) => {
+        if (!editor.isFocused) {
+            editor.commands.focus();
+        }
+        const form = e.target.closest('form.cms-inline-form');
+        if (!form) {
+            _handleToolbarClick(e, editor);
+        }
+    });
+}
+
 function _createTopToolbarPlugin(editor, filter) {
     'use strict';
     return new Plugin({
         props: {
-            decorations(state) {
-                return this.getState(state);
-            },
             handleDOMEvents: {
-                mousedown (view, event) {
-                    const form = event.target.closest('form.cms-inline-form');
-                    if (editor.options.topToolbar?.contains(event.target) && !form) {
-                        event.preventDefault();
-                        return true;
+                click (view, event) {
+                    // Close dropdowns when clicking inside the editor content
+                    if (!editor.options.topToolbar?.contains(event.target)) {
+                        return _closeAllDropdowns(event, editor) > 0;
                     }
                     return false;
                 },
-                click (view, event) {
-                    if (editor.options.topToolbar?.contains(event.target)) {
-                        const form = event.target.closest('form.cms-inline-form');
-                        if (form && editor.options.topToolbar.contains(form) ) {
-                            // Let the form handle clicks inside it
-                            return false;
-                        }
-                        if (!editor.isFocused) {
-                            editor.commands.focus();
-                        }
-                        _handleToolbarClick(event, editor);
-                        return true;
-                    }
-                    return _closeAllDropdowns(event, editor) > 0;
-                },
             }
         },
-        state: {
-            init(_, {doc}) {
-                return DecorationSet.create(doc, [
-                    Decoration.widget(0, () => {
-                        const topToolbar = _createToolbar(
-                            editor,
-                            editor.options.toolbar,
-                            filter
-                        );
-                        editor.options.topToolbar = topToolbar;
-
-                        if (!editor.options.element.classList.contains('fixed')) {
-                            // Inline editors: toolbar is position:fixed to escape
-                            // overflow:hidden on ancestors. Position via JS.
-                            editor.options._cleanupScrollPin = _positionFixedToolbar(
-                                editor.options.element, topToolbar
-                            );
-                            return topToolbar;
-                        }
-                        // Fixed toolbar: sticky positioning keeps it in view
-                        // within the editor's scroll container
-                        return topToolbar;
-                    }, {
-                        side: -1,
-                        ignoreSelection: true,
-                        key: "topToolbar",
-                    })
-                ]);
-            },
-            apply(tr, value) { return value; }
-        }
     });
 }
 
@@ -706,6 +745,13 @@ const CmsToolbarPlugin = Extension.create({
     onCreate() {
         const editor = this.editor;
         const hasBlockToolbar = editor.options.blockToolbar;
+        const {el} = editor.options;
+        const el_rect = el.getBoundingClientRect();
+        const filter = (el.tagName !== 'TEXTAREA' && el_rect.x >= 28) ? 'mark' : undefined;
+
+        // Create toolbar outside ProseMirror's decoration system
+        _initTopToolbar(editor, filter);
+
         let lastFrom = -1;
         let lastTo = -1;
         let toolbarRafId = 0;
@@ -739,6 +785,14 @@ const CmsToolbarPlugin = Extension.create({
         });
     },
     onDestroy() {
+        // Remove toolbar from DOM
+        if (this.editor.options._toolbarHost) {
+            this.editor.options._toolbarHost.remove();
+            delete this.editor.options._toolbarHost;
+        } else if (this.editor.options.topToolbar) {
+            this.editor.options.topToolbar.remove();
+        }
+        delete this.editor.options.topToolbar;
         if (this.editor.options._cleanupScrollPin) {
             this.editor.options._cleanupScrollPin();
             delete this.editor.options._cleanupScrollPin;

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -187,7 +187,7 @@ function updateBlockToolbar(editor, state) {
         blockToolbar.dataset.end = startPos + resolvedPos.node(depth).nodeSize;
         blockToolbar.dataset.depth = depth;
         const pos = editor.view.coordsAtPos(startPos);
-        const ref = editor.options.el.getBoundingClientRect();
+        const ref = (editor.options.el || editor.options.element).getBoundingClientRect();
         blockToolbar.draggable = resolvedPos.node(depth).content.size > 0;
         blockToolbar.style.insetBlockStart = `${pos.top - ref.top}px`;
         let title = resolvedPos.node(1)?.type.name;
@@ -416,14 +416,19 @@ function _positionFixedToolbar(editorElement, toolbar) {
 
     const scrollTarget = _findScrollParent(editorElement);
     scrollTarget.addEventListener('scroll', scheduleUpdate, {passive: true});
-    window.addEventListener('scroll', scheduleUpdate, {passive: true});
+    // Only attach the window listener if the scroll parent isn't the window itself
+    if (scrollTarget !== window) {
+        window.addEventListener('scroll', scheduleUpdate, {passive: true});
+    }
     window.addEventListener('resize', onResize, {passive: true});
     // Defer initial positioning so the toolbar has been rendered and has a height
     requestAnimationFrame(onResize);
 
     return () => {
         scrollTarget.removeEventListener('scroll', scheduleUpdate);
-        window.removeEventListener('scroll', scheduleUpdate);
+        if (scrollTarget !== window) {
+            window.removeEventListener('scroll', scheduleUpdate);
+        }
         window.removeEventListener('resize', onResize);
         if (rafId) { cancelAnimationFrame(rafId); }
     };
@@ -490,7 +495,8 @@ function _handleToolbarClick(event, editor) {
     'use strict';
     event.preventDefault();
     const button = event.target.closest('button, .dropdown');
-    if (button && !button.disabled && !editor.options.el.querySelector('dialog.cms-form-dialog')) {
+    const editorEl = editor.options.el || editor.options.element;
+    if (button && !button.disabled && !editorEl.querySelector('dialog.cms-form-dialog')) {
         const {action} = button.dataset;
         if (button.classList.contains('dropdown')) {
             // Open dropdown
@@ -708,7 +714,8 @@ function _updateToolbar(editor, toolbar) {
     // child is active (avoids expensive :has() CSS selector)
     const SKIP_ACTIONS = new Set(['Heading1','Heading2','Heading3','Heading4','Heading5','Heading6','Paragraph']);
     const topToolbar = editor.options.topToolbar;
-    if (!topToolbar) { editor.options.el.dataset.selecting = 'false'; return; }
+    const editorEl = editor.options.el || editor.options.element;
+    if (!topToolbar) { editorEl.dataset.selecting = 'false'; return; }
     for (const dropdown of topToolbar.querySelectorAll('.dropdown')) {
         const hasActive = Array.from(dropdown.querySelectorAll('.active'))
             .some(el => !SKIP_ACTIONS.has(el.dataset.action));
@@ -716,7 +723,7 @@ function _updateToolbar(editor, toolbar) {
             dropdown.classList.toggle('has-active-child', hasActive);
         }
     }
-    editor.options.el.dataset.selecting = 'false';
+    editorEl.dataset.selecting = 'false';
 }
 
 function _submitToolbarForm(event, editor) {
@@ -750,7 +757,7 @@ const CmsToolbarPlugin = Extension.create({
     onCreate() {
         const editor = this.editor;
         const hasBlockToolbar = editor.options.blockToolbar;
-        const {el} = editor.options;
+        const el = editor.options.el || editor.options.element;
         const el_rect = el.getBoundingClientRect();
         const filter = (el.tagName !== 'TEXTAREA' && el_rect.x >= 28) ? 'mark' : undefined;
 
@@ -805,6 +812,8 @@ const CmsToolbarPlugin = Extension.create({
             this.editor.options.topToolbar.remove();
         }
         delete this.editor.options.topToolbar;
+        // Invalidate cached button list
+        delete this.editor.options._cachedToolbarButtons;
         if (this.editor.options._cleanupScrollPin) {
             this.editor.options._cleanupScrollPin();
             delete this.editor.options._cleanupScrollPin;
@@ -812,7 +821,7 @@ const CmsToolbarPlugin = Extension.create({
     },
     addProseMirrorPlugins() {
         'use strict';
-        const {el} = this.editor.options;
+        const el = this.editor.options.el || this.editor.options.element;
         const el_rect = el.getBoundingClientRect();
         if (el.tagName === 'TEXTAREA' || el_rect.x < 28) {
             // Not inline or too close to the left edge to see the block toolbar

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -304,13 +304,12 @@ function _createTopToolbarPlugin(editor, filter) {
                         editor.options.topToolbar = topToolbar;
 
                         if (!editor.options.element.classList.contains('fixed')) {
-                            // For inline editors: wrap in an absolutely positioned
-                            // container and pin it on scroll
-                            const wrapper = document.createElement('div');
-                            wrapper.classList.add('cms-toolbar-sticky');
-                            wrapper.appendChild(topToolbar);
-                            editor.options._cleanupScrollPin = _pinToolbarOnScroll(editor.options.element, wrapper, true);
-                            return wrapper;
+                            // Inline editors: toolbar is position:fixed to escape
+                            // overflow:hidden on ancestors. Position via JS.
+                            editor.options._cleanupScrollPin = _positionFixedToolbar(
+                                editor.options.element, topToolbar
+                            );
+                            return topToolbar;
                         }
                         // Fixed toolbar: sticky positioning keeps it in view
                         // within the editor's scroll container
@@ -328,13 +327,53 @@ function _createTopToolbarPlugin(editor, filter) {
 }
 
 /**
- * Keeps an absolutely positioned toolbar visible by adjusting its top offset
- * on scroll. Repositions the toolbar so it doesn't scroll out of view,
- * working around overflow:hidden on ancestors that would break sticky positioning.
+/**
+ * Positions a fixed toolbar above the editor element.
+ * The toolbar uses position:fixed to escape ancestor overflow:hidden clipping.
+ * Its position is updated on scroll to stay above the editor, clamped to the
+ * CMS toolbar bottom edge.
  *
  * @param {HTMLElement} editorElement - The editor wrapper element.
- * @param {HTMLElement} toolbar - The toolbar (or toolbar wrapper) element to pin.
+ * @param {HTMLElement} toolbar - The menubar element (position:fixed).
+ * @returns {Function} Cleanup function to remove event listeners.
  */
+function _positionFixedToolbar(editorElement, toolbar) {
+    const cmsToolbarHeight = parseInt(
+        getComputedStyle(document.documentElement)
+            .getPropertyValue('--cms-toolbar-height') || '0', 10
+    );
+
+    function update() {
+        const rect = editorElement.getBoundingClientRect();
+        const toolbarHeight = toolbar.offsetHeight || 0;
+
+        // Position toolbar above the editor, or pin to CMS toolbar bottom
+        const idealTop = rect.top - toolbarHeight - 6;
+        const minTop = cmsToolbarHeight;
+        // Hide if editor is scrolled out of view
+        const editorBottom = rect.bottom;
+        if (editorBottom < cmsToolbarHeight + toolbarHeight || rect.top > window.innerHeight) {
+            toolbar.style.top = '-9999px';
+        } else {
+            toolbar.style.top = Math.max(idealTop, minTop) + 'px';
+        }
+        toolbar.style.left = rect.left + 'px';
+    }
+
+    const scrollTarget = _findScrollParent(editorElement);
+    // No RAF debounce: updating top/left on a fixed element is cheap
+    // and avoids the one-frame lag that makes the toolbar visibly trail
+    scrollTarget.addEventListener('scroll', update, {passive: true});
+    window.addEventListener('scroll', update, {passive: true});
+    // Defer initial positioning so the toolbar has been rendered and has a height
+    requestAnimationFrame(update);
+
+    return () => {
+        scrollTarget.removeEventListener('scroll', update);
+        window.removeEventListener('scroll', update);
+    };
+}
+
 /**
  * Finds the nearest scrollable ancestor of an element, or falls back to window.
  *
@@ -353,68 +392,6 @@ function _findScrollParent(element) {
     return window;
 }
 
-function _pinToolbarOnScroll(editorElement, toolbar, isInline) {
-    const cmsToolbarHeight = parseInt(
-        getComputedStyle(document.documentElement)
-            .getPropertyValue('--cms-toolbar-height') || '0', 10
-    );
-
-    function update() {
-        const rect = editorElement.getBoundingClientRect();
-
-        if (isInline) {
-            // Inline toolbar: the menubar extends upward from the wrapper
-            // (bottom: 100%+6px). We need to offset the wrapper down so the
-            // menubar stays visible at the CMS toolbar bottom edge.
-            const menubar = toolbar.querySelector('[role="menubar"]');
-            const menubarHeight = menubar?.offsetHeight || 0;
-            // The point where the toolbar should start pinning:
-            // editor top has scrolled above (cmsToolbarHeight + menubarHeight)
-            const pinPoint = cmsToolbarHeight + menubarHeight + 6; // 6px gap
-            if (rect.top < pinPoint) {
-                const offset = pinPoint - rect.top;
-                // Clamp so toolbar doesn't go below the editor bottom
-                const maxOffset = rect.height - menubarHeight;
-                toolbar.style.top = Math.min(offset, Math.max(0, maxOffset)) + 'px';
-            } else {
-                toolbar.style.top = '0';
-            }
-        } else {
-            // Fixed toolbar: sits at top of editor, scrolls with content
-            const toolbarHeight = toolbar.offsetHeight || 0;
-            if (rect.top < cmsToolbarHeight) {
-                const offset = cmsToolbarHeight - rect.top;
-                const maxOffset = editorElement.scrollHeight - toolbarHeight;
-                toolbar.style.top = Math.min(offset, Math.max(0, maxOffset)) + 'px';
-            } else {
-                toolbar.style.top = '0';
-            }
-        }
-    }
-
-    let rafId = 0;
-    function onScroll() {
-        if (!rafId) {
-            rafId = requestAnimationFrame(() => {
-                rafId = 0;
-                update();
-            });
-        }
-    }
-
-    const scrollTarget = _findScrollParent(editorElement);
-    scrollTarget.addEventListener('scroll', onScroll, {passive: true});
-    update();
-
-    // Return cleanup function to remove the scroll listener
-    return () => {
-        scrollTarget.removeEventListener('scroll', onScroll);
-        if (rafId) {
-            cancelAnimationFrame(rafId);
-        }
-    };
-}
-
 /**
  * Creates a toolbar element for the editor.
  * A toolbar is a div element with role="toolbar" and class cms-toolbar.
@@ -430,12 +407,11 @@ function _createToolbar(editor, toolbar, filter) {
     const toolbarElement = document.createElement('div');
     toolbarElement.setAttribute('role', 'menubar');
     toolbarElement.classList.add('cms-toolbar');
-    toolbarElement.style.zIndex = editor.options.baseFloatZIndex || 8888888;  //
-
     // create the toolbar html from the settings
     toolbarElement.innerHTML = _populateToolbar(editor, toolbar, filter);
 
     if (!editor.options.element.classList.contains('fixed')) {
+        toolbarElement.style.zIndex = editor.options.baseFloatZIndex || 8888888;
         // Limit its width to the available space
         toolbarElement.style.maxWidth = (window.innerWidth - toolbarElement.getBoundingClientRect().left - 16) + 'px';
     }

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -370,17 +370,25 @@ function _positionFixedToolbar(editorElement, toolbar) {
         update();
     }
 
+    let rafId = 0;
+    function scheduleUpdate() {
+        if (!rafId) {
+            rafId = requestAnimationFrame(() => { rafId = 0; update(); });
+        }
+    }
+
     const scrollTarget = _findScrollParent(editorElement);
-    scrollTarget.addEventListener('scroll', update, {passive: true});
-    window.addEventListener('scroll', update, {passive: true});
+    scrollTarget.addEventListener('scroll', scheduleUpdate, {passive: true});
+    window.addEventListener('scroll', scheduleUpdate, {passive: true});
     window.addEventListener('resize', onResize, {passive: true});
     // Defer initial positioning so the toolbar has been rendered and has a height
     requestAnimationFrame(onResize);
 
     return () => {
-        scrollTarget.removeEventListener('scroll', update);
-        window.removeEventListener('scroll', update);
+        scrollTarget.removeEventListener('scroll', scheduleUpdate);
+        window.removeEventListener('scroll', scheduleUpdate);
         window.removeEventListener('resize', onResize);
+        if (rafId) { cancelAnimationFrame(rafId); }
     };
 }
 
@@ -700,6 +708,7 @@ const CmsToolbarPlugin = Extension.create({
         const hasBlockToolbar = editor.options.blockToolbar;
         let lastFrom = -1;
         let lastTo = -1;
+        let toolbarRafId = 0;
         editor.on('transaction', () => {
             // Skip if tab is hidden
             if (document.hidden) {
@@ -717,9 +726,15 @@ const CmsToolbarPlugin = Extension.create({
             }
             lastFrom = from;
             lastTo = to;
-            _updateToolbar(editor);
-            if (hasBlockToolbar) {
-                updateBlockToolbar(editor);
+            // Coalesce rapid transactions into a single paint frame
+            if (!toolbarRafId) {
+                toolbarRafId = requestAnimationFrame(() => {
+                    toolbarRafId = 0;
+                    _updateToolbar(editor);
+                    if (hasBlockToolbar) {
+                        updateBlockToolbar(editor);
+                    }
+                });
             }
         });
     },

--- a/tests/js/cms.editor.test.js
+++ b/tests/js/cms.editor.test.js
@@ -132,6 +132,43 @@ describe('CMSEditor', () => {
         expect(Object.keys(editor._editor_settings).length).toBe(2);
     });
 
+    it('destroys orphaned editors when DOM is replaced', () => {
+        const plugin = window.cms_editor_plugin;
+
+        // Create editors
+        editor.initAll();
+        expect(plugin._editors.editor1).toBeDefined();
+        expect(plugin._editors.editor1.isDestroyed).toBe(false);
+
+        const oldEditor = plugin._editors.editor1;
+
+        // Simulate CMS replacing the DOM: remove the editor's rendered element
+        const editorElement = oldEditor.options.element;
+        editorElement.remove();
+
+        // _resetInlineEditors should detect the orphaned editor and destroy it
+        editor._resetInlineEditors();
+
+        expect(oldEditor.isDestroyed).toBe(true);
+        expect(plugin._editors.editor1).toBeUndefined();
+    });
+
+    it('keeps editors whose DOM is still present', () => {
+        const plugin = window.cms_editor_plugin;
+
+        editor.initAll();
+        expect(plugin._editors.editor1).toBeDefined();
+
+        const oldEditor = plugin._editors.editor1;
+
+        // DOM is NOT replaced — editor element still present
+        editor._resetInlineEditors();
+
+        // Editor should be kept, not destroyed
+        expect(oldEditor.isDestroyed).toBe(false);
+        expect(plugin._editors.editor1).toBe(oldEditor);
+    });
+
     it('highlights text plugin', () => {
         const pluginId = 'test-plugin';
         document.body.innerHTML += `<div class="cms-draggable-${pluginId}"></div>`;

--- a/tests/js/cms.tiptap.toolbar.test.js
+++ b/tests/js/cms.tiptap.toolbar.test.js
@@ -124,4 +124,89 @@ describe('Tiptap toolbar items', () => {
         // If this entry remains, it's a bug in destroyRTE/destroyEditor
         expect(plugin._editors.editor1).toBeUndefined();
     });
+
+    describe('editor.options.el and editor.options.element consistency', () => {
+        it('sets both options.el and options.element on a textarea editor', () => {
+            const plugin = window.cms_editor_plugin;
+            const el = document.getElementById('editor1');
+            editor.init(el);
+
+            const tiptap = plugin._editors.editor1;
+            expect(tiptap).toBeDefined();
+            // Both options must be defined
+            expect(tiptap.options.el).toBeDefined();
+            expect(tiptap.options.element).toBeDefined();
+            // For textareas, el is the textarea and element is the wrapper div
+            expect(tiptap.options.el).toBe(el);
+            expect(tiptap.options.el.tagName).toBe('TEXTAREA');
+            expect(tiptap.options.element.tagName).toBe('DIV');
+            // The wrapper element should be a sibling of the textarea
+            expect(tiptap.options.element).not.toBe(tiptap.options.el);
+        });
+
+        it('toolbar plugin works when only options.el is set (legacy)', () => {
+            const plugin = window.cms_editor_plugin;
+            const el = document.getElementById('editor1');
+            editor.init(el);
+
+            const tiptap = plugin._editors.editor1;
+            // Verify the toolbar code paths used both via fallback
+            // (cms.toolbar.js uses `editor.options.el || editor.options.element`)
+            const fallbackEl = tiptap.options.el || tiptap.options.element;
+            expect(fallbackEl).toBeDefined();
+            expect(typeof fallbackEl.getBoundingClientRect).toBe('function');
+            expect(fallbackEl.tagName).toBeDefined();
+        });
+
+        it('toolbar plugin works when only options.element is set', () => {
+            const plugin = window.cms_editor_plugin;
+            const el = document.getElementById('editor1');
+            editor.init(el);
+
+            const tiptap = plugin._editors.editor1;
+            // Simulate a setup where `el` is missing - the fallback should work
+            const originalEl = tiptap.options.el;
+            delete tiptap.options.el;
+
+            const fallbackEl = tiptap.options.el || tiptap.options.element;
+            expect(fallbackEl).toBeDefined();
+            expect(fallbackEl).toBe(tiptap.options.element);
+            expect(typeof fallbackEl.getBoundingClientRect).toBe('function');
+
+            // Restore
+            tiptap.options.el = originalEl;
+        });
+
+        it('source code uses fallback pattern for editor.options.el access in cms.toolbar.js', async () => {
+            // Static check: ensure all direct accesses of editor.options.el in
+            // cms.toolbar.js are guarded with a fallback to editor.options.element.
+            // This catches regressions where new code uses options.el directly.
+            const fs = require('fs');
+            const path = require('path');
+            const filePath = path.resolve(
+                __dirname, '../../private/js/tiptap_plugins/cms.toolbar.js'
+            );
+            const source = fs.readFileSync(filePath, 'utf8');
+            // Find all .options.el access without `||` fallback or `.element`
+            // Allowed patterns:
+            //   editor.options.el || editor.options.element
+            //   this.editor.options.el || this.editor.options.element
+            //   editor.options.element  (no .el at all)
+            // Disallowed: standalone `editor.options.el` reads (without fallback)
+            const lines = source.split('\n');
+            const offenders = [];
+            lines.forEach((line, idx) => {
+                // Match `.options.el` not followed by `ement` (to exclude `.options.element`)
+                // and not in a chain that includes a fallback `|| ... .element`
+                const match = line.match(/\.options\.el(?!ement)/);
+                if (match) {
+                    // Check if the same line contains a fallback to .element
+                    if (!line.includes('options.element')) {
+                        offenders.push(`Line ${idx + 1}: ${line.trim()}`);
+                    }
+                }
+            });
+            expect(offenders).toEqual([]);
+        });
+    });
 });


### PR DESCRIPTION
## Summary by Sourcery

Improve lifecycle and performance of inline TipTap editors and toolbars to prevent leaks and keep state in sync with the DOM.

Bug Fixes:
- Avoid redundant block toolbar updates when the active block has not changed and reset its internal state when no block is active.
- Destroy orphaned rich-text and plain-text editors whose DOM elements were removed when the CMS replaces plugin HTML.
- Ensure CmsTextEditor correctly removes focus/blur listeners on destroy by storing bound handler references.
- Prevent CMS tooltips from appearing over inline editors by stopping delegated pointer events.
- Avoid excessive toolbar state recomputation by skipping updates when the selection is unchanged or the editor is unfocused, and by caching toolbar buttons.

Enhancements:
- Move the top toolbar out of the ProseMirror decoration system and into a fixed-position element that is synced to the editor via scroll listeners.
- Introduce a fixed-position inline toolbar host with CSS updates to control its visibility and dropdown behavior independently of the editor DOM.
- Refine toolbar positioning logic to account for the global CMS toolbar, viewport visibility, and scrollable ancestors, with a reusable positioning helper.
- Cache toolbar button lookups and initial toolbar state updates for more efficient UI refreshes.
- Adjust TipTap form integration so editor content is written back to hidden fields on form submit while still triggering Django change detection earlier via cleared fields.
- Relax containment settings on tiptap containers to support the fixed toolbar while enabling layout containment on the content area.

Tests:
- Add regression tests ensuring orphaned editors are destroyed when their DOM is replaced and preserved when their DOM remains present.