### PR TITLE
fix: Create dblClick guard to capture dblClick + drag

### DIFF
--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -25,35 +25,37 @@
 }
 
 .cms-editor-inline-wrapper {
-    &.textarea .tiptap {
-        border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
-        padding: 6px;
-        min-height: 3rem;
-        border-radius: 0 0 4px 4px;
-    }
-    &.textarea.fixed > [role="menubar"] {
-        border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
-        border-bottom: none;
-        border-radius: 4px 4px 0 0;
-    }
-    /* Focus outline encompasses both toolbar and editor content */
-    &.textarea:has(.ProseMirror-focused) {
-        border-radius: 4px;
-        box-shadow: 0 0 0 3px AccentColor;
-    }
-    /* Hide the inner outline on .tiptap when wrapper has the outline */
-    &.textarea .tiptap.ProseMirror-focused {
-        outline: none;
-    }
-
-    &.textarea.fixed .tiptap {
-        padding-top: 0;
-        resize: vertical;
-        overflow-y: auto;
-        contain: none; /* Fixed toolbar uses sticky inside tiptap */
-    }
-
     position: relative;
+
+    /* HTMLField (textarea) widget styling: border wraps both toolbar and content */
+    &.textarea {
+        .tiptap {
+            border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
+            padding: 6px;
+            min-height: 3rem;
+            border-radius: 0 0 4px 4px;
+        }
+        &.fixed > [role="menubar"] {
+            border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
+            border-bottom: none;
+            border-radius: 4px 4px 0 0;
+        }
+        &.fixed .tiptap {
+            padding-top: 0;
+            resize: vertical;
+            overflow-y: auto;
+            contain: none; /* Fixed toolbar uses sticky inside tiptap */
+        }
+        /* Focus outline encompasses both toolbar and editor content */
+        &:has(.ProseMirror-focused) {
+            border-radius: 4px;
+            box-shadow: 0 0 0 3px AccentColor;
+        }
+        /* Hide the inner outline on .tiptap when wrapper has the outline */
+        .tiptap.ProseMirror-focused {
+            outline: none;
+        }
+    }
 
     .tiptap {
         min-height: 1em;
@@ -72,6 +74,10 @@
             /* Safari: Only outline the editor div, not toolbar etc. */
             outline: 3px solid AccentColor;
             outline-offset: 2px;
+
+            td, th {
+                outline: Highlight solid 0.5px;
+            }
         }
 
         &.resize-cursor {
@@ -105,12 +111,6 @@
                 position: absolute;
                 background: AccentColor;
                 box-shadow: 0 0 2px AccentColor;
-            }
-        }
-
-        &.ProseMirror-focused {
-            td, th {
-                outline: Highlight solid 0.5px;
             }
         }
 

--- a/private/css/cms.tiptap.css
+++ b/private/css/cms.tiptap.css
@@ -31,7 +31,7 @@
         min-height: 3rem;
         border-radius: 0 0 4px 4px;
     }
-    &.textarea > [role="menubar"] {
+    &.textarea.fixed > [role="menubar"] {
         border: 1px solid var(--dca-gray-lighter, var(--hairline-color));
         border-bottom: none;
         border-radius: 4px 4px 0 0;

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -1,4 +1,4 @@
-/* Position sticky toolbar below the django CMS toolbar when it's visible */
+/* CMS toolbar height is needed to position the editor toolbar below it */
 html.cms-toolbar-expanded {
     --cms-toolbar-height: 46px;
 }
@@ -56,31 +56,24 @@ html.cms-toolbar-expanded {
     }
     &.fixed [role="menubar"]  {
         display: block;
+        position: sticky;
         top: 0;
         bottom: unset;
         inset-inline-start: unset;
+        width: 100%;
         min-width: unset;
         z-index: 2;
+        box-sizing: border-box;
         visibility: visible;
         opacity: 1;
-        transition: visibility var(--tiptap-ease, 100ms);
-        [role="button"].show {
-            z-index: 10;
-            > .dropdown-content {
-                visibility: visible;
-                height: auto;
-            }
-        }
-        position: sticky;
-        width: 100%;
-        box-sizing: border-box;
         outline: none;
-        box-shadow: none;
         border: none;
         border-bottom: 1px solid var(--dca-gray-lighter, var(--hairline-color));
         border-radius: 0;
+        box-shadow: none;
         padding-left: 0;
         padding-right: 0;
+        transition: visibility var(--tiptap-ease, 100ms);
         .dropdown-content {
             inset-block-start: 100%;
             inset-inline-start: -2px;
@@ -298,7 +291,7 @@ html.cms-toolbar-expanded {
     .toolbar-dropback {
         display: none;
     }
-    .has-dropdown-open .toolbar-dropback {
+    [role="menubar"].has-dropdown-open .toolbar-dropback {
         display: block;
     }
 
@@ -328,7 +321,6 @@ html.cms-toolbar-expanded {
         color: var(--dca-gray);
         border-radius: 3px;
         box-shadow: none;
-        /* box-shadow: 0 1.5px 1.5px rgba(var(--dca-shadow),.4); */
         inset-inline-end: calc(100% + 0.75rem);
         width: calc(1.6 * var(--size));
         height:  calc(1.6 * var(--size));

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -76,6 +76,9 @@ html.cms-toolbar-expanded {
         box-sizing: border-box;
         outline: none;
         box-shadow: none;
+        border: none;
+        border-bottom: 1px solid var(--dca-gray-lighter, var(--hairline-color));
+        border-radius: 0;
         padding-left: 0;
         padding-right: 0;
         .dropdown-content {

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -44,41 +44,59 @@ function _installInlineDblclickGuard() {
     }
     _inlineDblclickGuardInstalled = true;
 
-    let mouseDownInsideInline = false;
+    // Track the wrapper where the gesture started, not just a boolean.
+    // We need the wrapper element to check if it has an active editor.
+    let mouseDownWrapper = null;
 
-    const isInsideInline = (target) => !!(
-        target && target.nodeType === 1 &&
-        target.closest && target.closest('.cms-editor-inline-wrapper')
-    );
+    // Find the enclosing inline editor wrapper for a target element.
+    const findInlineWrapper = (target) => {
+        if (!target || target.nodeType !== 1 || !target.closest) {
+            return null;
+        }
+        return target.closest('.cms-editor-inline-wrapper');
+    };
+
+    // Only suppress the CMS modal if the wrapper has an *initialized* editor.
+    // If editor creation failed (e.g. bad content), the fallback to the CMS
+    // modal editor should still work via a regular double-click.
+    const wrapperHasEditor = (wrapper) => {
+        if (!wrapper || !wrapper.id) {
+            return false;
+        }
+        const tiptapEditors = window.cms_editor_plugin?._editors || {};
+        const genericEditors = window.CMS_Editor?._generic_editors || {};
+        return wrapper.id in tiptapEditors || wrapper.id in genericEditors;
+    };
 
     document.addEventListener('mousedown', (event) => {
         // Only primary button starts a double-click gesture we care about
         if (event.button !== 0) {
-            mouseDownInsideInline = false;
+            mouseDownWrapper = null;
             return;
         }
-        mouseDownInsideInline = isInsideInline(event.target);
+        mouseDownWrapper = findInlineWrapper(event.target);
     }, true);
 
     document.addEventListener('dblclick', (event) => {
         if (event.button !== 0) {
             return;
         }
-        if (isInsideInline(event.target) || mouseDownInsideInline) {
+        const currentWrapper = findInlineWrapper(event.target);
+        const wrapper = currentWrapper || mouseDownWrapper;
+        if (wrapper && wrapperHasEditor(wrapper)) {
             // Stop the event before it reaches document's bubble phase,
             // where jQuery's delegated `.cms-plugin` handler lives.
             event.stopPropagation();
         }
-        // Reset the flag so it doesn't leak across subsequent interactions.
-        mouseDownInsideInline = false;
+        // Reset the gesture state after the dblclick is handled.
+        mouseDownWrapper = null;
     }, true);
 
-    // Safety net: reset on mouseup so a lingering flag doesn't outlive a
-    // gesture that never produced a dblclick.
+    // Safety net: clear the gesture state on mouseup if no dblclick follows.
     document.addEventListener('mouseup', () => {
         // Defer to the next tick so a dblclick handler that fires after
-        // mouseup can still observe the flag.
-        setTimeout(() => { mouseDownInsideInline = false; }, 0);
+        // mouseup can still observe the wrapper reference.
+        setTimeout(() => { mouseDownWrapper = null; }, 0);
     }, true);
 }
 

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -128,6 +128,47 @@ class CMSEditor {
             ? (cb) => requestIdleCallback(cb, {timeout: 2000})
             : (cb) => setTimeout(cb, 0);
 
+        // Install a one-time document-level guard that prevents CMS's delegated
+        // `dblclick.cms.plugin` handler from opening the modal editor when the
+        // double-click belongs to an inline editor (tiptap or generic text editor).
+        //
+        // Why this needs to live on `document` in capture phase, and not on the
+        // wrapper itself:
+        //   * django-cms binds `dblclick.cms.plugin` via jQuery delegation on
+        //     `document`, so `.off('dblclick.cms.plugin')` on the wrapper is a
+        //     no-op — only stopping propagation before it reaches `document`'s
+        //     bubble phase actually disarms it.
+        //   * For a plain double-click the wrapper-bound handler is enough, but
+        //     for "double-click + drag to extend by word" the second mouseup
+        //     lands on a different node (often outside the wrapper), so the
+        //     dblclick that jQuery ultimately routes never bubbles through the
+        //     wrapper at all. We therefore also remember whether the preceding
+        //     mousedown originated inside an inline wrapper and use that as a
+        //     fallback signal.
+        if (!this._inlineDblclickGuardInstalled) {
+            let mouseDownInsideInline = false;
+            document.addEventListener('mousedown', (event) => {
+                const target = event.target;
+                mouseDownInsideInline = !!(
+                    target && target.nodeType === 1 &&
+                    target.closest && target.closest('.cms-editor-inline-wrapper')
+                );
+            }, true);
+            document.addEventListener('dblclick', (event) => {
+                const target = event.target;
+                const insideInline = !!(
+                    target && target.nodeType === 1 &&
+                    target.closest && target.closest('.cms-editor-inline-wrapper')
+                );
+                if (insideInline || mouseDownInsideInline) {
+                    // Stop the event before it reaches document's bubble phase,
+                    // where jQuery's delegated `.cms-plugin` handler lives.
+                    event.stopPropagation();
+                }
+            }, true);
+            this._inlineDblclickGuardInstalled = true;
+        }
+
         this.observer = this.observer || new IntersectionObserver( (entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {

--- a/private/js/cms.editor.js
+++ b/private/js/cms.editor.js
@@ -15,6 +15,73 @@ const WRAPPER_TAGS = new Set([
     'HEADER', 'FOOTER', 'NAV', 'CMS-PLUGIN',
 ]);
 
+// Module-level flag so multiple CMSEditor instances don't each install the
+// document-level dblclick guard listeners.
+let _inlineDblclickGuardInstalled = false;
+
+/**
+ * Installs a one-time document-level capture-phase guard that prevents CMS's
+ * delegated `dblclick.cms.plugin` handler from opening the modal editor when
+ * the double-click belongs to an inline editor (tiptap or generic text editor).
+ *
+ * Why this needs to live on `document` in capture phase, and not on the
+ * wrapper itself:
+ *   * django-cms binds `dblclick.cms.plugin` via jQuery delegation on
+ *     `document`, so `.off('dblclick.cms.plugin')` on the wrapper is a
+ *     no-op — only stopping propagation before it reaches `document`'s
+ *     bubble phase actually disarms it.
+ *   * For a plain double-click the wrapper-bound handler is enough, but
+ *     for "double-click + drag to extend by word" the second mouseup
+ *     lands on a different node (often outside the wrapper), so the
+ *     dblclick that jQuery ultimately routes never bubbles through the
+ *     wrapper at all. We therefore also remember whether the preceding
+ *     mousedown originated inside an inline wrapper and use that as a
+ *     fallback signal.
+ */
+function _installInlineDblclickGuard() {
+    if (_inlineDblclickGuardInstalled) {
+        return;
+    }
+    _inlineDblclickGuardInstalled = true;
+
+    let mouseDownInsideInline = false;
+
+    const isInsideInline = (target) => !!(
+        target && target.nodeType === 1 &&
+        target.closest && target.closest('.cms-editor-inline-wrapper')
+    );
+
+    document.addEventListener('mousedown', (event) => {
+        // Only primary button starts a double-click gesture we care about
+        if (event.button !== 0) {
+            mouseDownInsideInline = false;
+            return;
+        }
+        mouseDownInsideInline = isInsideInline(event.target);
+    }, true);
+
+    document.addEventListener('dblclick', (event) => {
+        if (event.button !== 0) {
+            return;
+        }
+        if (isInsideInline(event.target) || mouseDownInsideInline) {
+            // Stop the event before it reaches document's bubble phase,
+            // where jQuery's delegated `.cms-plugin` handler lives.
+            event.stopPropagation();
+        }
+        // Reset the flag so it doesn't leak across subsequent interactions.
+        mouseDownInsideInline = false;
+    }, true);
+
+    // Safety net: reset on mouseup so a lingering flag doesn't outlive a
+    // gesture that never produced a dblclick.
+    document.addEventListener('mouseup', () => {
+        // Defer to the next tick so a dblclick handler that fires after
+        // mouseup can still observe the flag.
+        setTimeout(() => { mouseDownInsideInline = false; }, 0);
+    }, true);
+}
+
 
 class CMSEditor {
 
@@ -128,46 +195,9 @@ class CMSEditor {
             ? (cb) => requestIdleCallback(cb, {timeout: 2000})
             : (cb) => setTimeout(cb, 0);
 
-        // Install a one-time document-level guard that prevents CMS's delegated
-        // `dblclick.cms.plugin` handler from opening the modal editor when the
-        // double-click belongs to an inline editor (tiptap or generic text editor).
-        //
-        // Why this needs to live on `document` in capture phase, and not on the
-        // wrapper itself:
-        //   * django-cms binds `dblclick.cms.plugin` via jQuery delegation on
-        //     `document`, so `.off('dblclick.cms.plugin')` on the wrapper is a
-        //     no-op — only stopping propagation before it reaches `document`'s
-        //     bubble phase actually disarms it.
-        //   * For a plain double-click the wrapper-bound handler is enough, but
-        //     for "double-click + drag to extend by word" the second mouseup
-        //     lands on a different node (often outside the wrapper), so the
-        //     dblclick that jQuery ultimately routes never bubbles through the
-        //     wrapper at all. We therefore also remember whether the preceding
-        //     mousedown originated inside an inline wrapper and use that as a
-        //     fallback signal.
-        if (!this._inlineDblclickGuardInstalled) {
-            let mouseDownInsideInline = false;
-            document.addEventListener('mousedown', (event) => {
-                const target = event.target;
-                mouseDownInsideInline = !!(
-                    target && target.nodeType === 1 &&
-                    target.closest && target.closest('.cms-editor-inline-wrapper')
-                );
-            }, true);
-            document.addEventListener('dblclick', (event) => {
-                const target = event.target;
-                const insideInline = !!(
-                    target && target.nodeType === 1 &&
-                    target.closest && target.closest('.cms-editor-inline-wrapper')
-                );
-                if (insideInline || mouseDownInsideInline) {
-                    // Stop the event before it reaches document's bubble phase,
-                    // where jQuery's delegated `.cms-plugin` handler lives.
-                    event.stopPropagation();
-                }
-            }, true);
-            this._inlineDblclickGuardInstalled = true;
-        }
+        // Guard CMS's delegated dblclick handler for all inline editors.
+        // Shared across all CMSEditor instances via a module-level flag.
+        _installInlineDblclickGuard();
 
         this.observer = this.observer || new IntersectionObserver( (entries) => {
             entries.forEach((entry) => {
@@ -227,20 +257,13 @@ class CMSEditor {
                 }
 
                 if (wrapper) {
-                    // Catch CMS single click event to highlight the plugin
-                    // Catch CMS double click event if present, since double click is needed by Editor
+                    // Catch CMS single click event to highlight the plugin.
+                    // Double-click suppression is handled by the document-level
+                    // capture-phase guard installed in initInlineEditors().
                     if (!Array.from(this.observer.root?.children || []).includes(wrapper)) {
                         // Only add to the observer if not already observed (e.g., if the page only was update partially)
                         this.observer.observe(wrapper);
                         if (this.CMS) {
-                            // Only suppress CMS double click if the inline editor was created
-                            // If creation fails, the default CMS modal editing should still work
-                            this.CMS.$(wrapper).off('dblclick.cms.plugin')
-                                .on('dblclick.cms-editor', function (event) {
-                                    if (wrapper.id && wrapper.id in (window.cms_editor_plugin?._editors || {})) {
-                                        event.stopPropagation();
-                                    }
-                                });
                             wrapper.addEventListener('focusin', () => {
                                 this._highlightTextplugin(id);
                             }, true);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent inline editors from inadvertently opening the CMS modal editor on double-click or double-click + drag by intercepting relevant dblclick events at the document level.