### PR TITLE
fix: Resize dialog on Safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .vscode/
 .settings/
 .tox/
+.claude/
 __pycache__/
 build/
 dist/

--- a/README.rst
+++ b/README.rst
@@ -420,7 +420,12 @@ frontends and CMS integration. To rebuild the bundle::
 
     nvm use
     npm install
-    npx webpack
+    npm run build
+
+Other build scripts:
+
+* ``npm run build:dev`` — unminified development build
+* ``npm run watch`` — rebuild on file changes
 
 
 Acknowledgments

--- a/djangocms_text/static/djangocms_text/css/cms.text.css
+++ b/djangocms_text/static/djangocms_text/css/cms.text.css
@@ -23,7 +23,6 @@
 
 #cms-top dialog.cms-dialog {
     padding: 0;
-    resize: both;
     top: 50%;
     left: 50%;
     inset-inline-start: 50%;
@@ -37,6 +36,39 @@
         width: 100%;
         height: 100%;
         border: none;
+    }
+    .cms-modal-resize {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        width: 24px;
+        height: 24px;
+        cursor: nwse-resize;
+        opacity: 0.5;
+        clip-path: polygon(100% 0, 100% 100%, 0 100%);
+        background: linear-gradient(
+            135deg,
+            transparent 0,
+            transparent 20%,
+            currentColor 20%,
+            currentColor 28%,
+            transparent 28%,
+            transparent 36%,
+            currentColor 36%,
+            currentColor 44%,
+            transparent 44%,
+            transparent 52%,
+            currentColor 52%,
+            currentColor 60%,
+            transparent 60%,
+            transparent 68%,
+            currentColor 68%,
+            currentColor 76%,
+            transparent 76%
+        );
+    }
+    .cms-modal-resize:hover {
+        opacity: 1;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "djangocms-text",
   "version": "1.0.0",
   "scripts": {
+    "build": "webpack --mode=production",
+    "build:dev": "webpack --mode=development",
+    "watch": "webpack --mode=development --watch",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/private/js/cms.dialog.js
+++ b/private/js/cms.dialog.js
@@ -50,6 +50,7 @@ class CmsDialog {
                     <div class="cms-modal-item-buttons"><a href="#" class="cms-btn cms-btn-close-action">Cancel</a></div>
                 </div>
             </div>
+            <span class="cms-modal-resize" aria-hidden="true"></span>
         `;
 
         (window.parent || window).document.querySelector('div.cms').prepend(this.dialog);
@@ -61,6 +62,12 @@ class CmsDialog {
         });
         this.dialog.querySelector('.cms-modal-title').addEventListener('touchstart', (event) => {
             this.swipeDialog(event);
+        });
+        this.dialog.querySelector('.cms-modal-resize').addEventListener('mousedown', (event) => {
+            this.resizeDialog(event);
+        });
+        this.dialog.querySelector('.cms-modal-resize').addEventListener('touchstart', (event) => {
+            this.touchResizeDialog(event);
         });
         const closeEvent = (event) => {
             event.stopPropagation();
@@ -232,6 +239,61 @@ class CmsDialog {
         Window.addEventListener('touchmove', swipeIt, false);
         Window.addEventListener('touchend', (e) => {
             Window.removeEventListener('touchmove', swipeIt, false);
+        }, false);
+    }
+
+    /**
+     * Resizes the dialog based on the user's mouse movements on the
+     * custom resize handle. Replaces native CSS `resize` because Safari
+     * clips the native handle to the dialog's rounded corner.
+     *
+     * @param {Event} event - The mouse event that triggers the resize.
+     */
+    resizeDialog(event) {
+        if (event.which !== 1) {
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        const firstX = event.pageX;
+        const firstY = event.pageY;
+        const initialW = parseInt(getComputedStyle(this.dialog).width);
+        const initialH = parseInt(getComputedStyle(this.dialog).height);
+
+        const resizeIt = (e) => {
+            this.dialog.style.width = initialW + e.pageX - firstX + 'px';
+            this.dialog.style.height = initialH + e.pageY - firstY + 'px';
+        };
+        const Window = window.parent || window;
+        Window.addEventListener('mousemove', resizeIt, false);
+        Window.addEventListener('mouseup', () => {
+            Window.removeEventListener('mousemove', resizeIt, false);
+        }, false);
+    }
+
+    /**
+     * Resizes the dialog based on the user's touch movements on the
+     * custom resize handle.
+     *
+     * @param {Event} event - The touch event that triggers the resize.
+     */
+    touchResizeDialog(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const firstX = event.touches[0].pageX;
+        const firstY = event.touches[0].pageY;
+        const initialW = parseInt(getComputedStyle(this.dialog).width);
+        const initialH = parseInt(getComputedStyle(this.dialog).height);
+
+        const resizeIt = (e) => {
+            const contact = e.touches;
+            this.dialog.style.width = initialW + contact[0].pageX - firstX + 'px';
+            this.dialog.style.height = initialH + contact[0].pageY - firstY + 'px';
+        };
+        const Window = window.parent || window;
+        Window.addEventListener('touchmove', resizeIt, false);
+        Window.addEventListener('touchend', () => {
+            Window.removeEventListener('touchmove', resizeIt, false);
         }, false);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a custom resize handle and mouse/touch-based resizing logic for the CMS dialog to replace native CSS resizing, improving behavior in Safari.

New Features:
- Introduce a visible custom resize handle element on the CMS dialog that supports mouse and touch interaction for resizing.

Enhancements:
- Remove reliance on native CSS `resize` in favor of a scripted resizing implementation compatible with Safari.
- Style the custom resize handle to visually indicate resizability while matching the dialog’s UI.
- Add npm build scripts using webpack for production and development builds, including a watch mode.

Build:
- Configure npm scripts to run webpack builds for production, development, and watch workflows.