### PR TITLE
fix: Remove unused JavaScript file from ckeditor4 config

### DIFF
--- a/djangocms_text/contrib/text_ckeditor4/__init__.py
+++ b/djangocms_text/contrib/text_ckeditor4/__init__.py
@@ -1,4 +1,3 @@
-from cms.utils.urlutils import static_with_version
 from django.conf import settings
 from django.templatetags.static import static
 from django.utils.functional import lazy

--- a/djangocms_text/contrib/text_ckeditor4/__init__.py
+++ b/djangocms_text/contrib/text_ckeditor4/__init__.py
@@ -25,7 +25,6 @@ ckeditor4 = RTEConfig(
     name="ckeditor4",
     config="CKEDITOR",
     js=(
-        static_with_version("cms/js/dist/bundle.admin.base.min.js"),
         BasePath(),
         "djangocms_text/vendor/ckeditor4/ckeditor.js",
         "djangocms_text/bundles/bundle.ckeditor4.min.js",

--- a/djangocms_text/contrib/text_ckeditor4/apps.py
+++ b/djangocms_text/contrib/text_ckeditor4/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 
 
 class TextCKEditor4App(AppConfig):
-    name = "text_ckeditor4"
+    name = "djangocms_text.contrib.text_ckeditor4"
 
     def ready(self):
         from cms.utils.urlutils import static_with_version

--- a/djangocms_text/contrib/text_ckeditor4/apps.py
+++ b/djangocms_text/contrib/text_ckeditor4/apps.py
@@ -2,6 +2,8 @@ from django.apps import AppConfig
 
 
 class TextCKEditor4App(AppConfig):
+    name = "text_ckeditor4"
+
     def ready(self):
         from cms.utils.urlutils import static_with_version
         from djangocms_text.widgets import TextEditorWidget

--- a/djangocms_text/contrib/text_ckeditor4/apps.py
+++ b/djangocms_text/contrib/text_ckeditor4/apps.py
@@ -1,0 +1,14 @@
+from django.apps import AppConfig
+
+
+class TextCKEditor4App(AppConfig):
+    def ready(self):
+        from cms.utils.urlutils import static_with_version
+        from djangocms_text.widgets import TextEditorWidget
+
+        # The legacy CKEditor4 widget needs CMS.$ from bundle.admin.base.min.js
+
+        TextEditorWidget.widget_js = (
+            *TextEditorWidget.widget_js,
+            static_with_version("cms/js/dist/bundle.admin.base.min.js"),
+        )

--- a/djangocms_text/widgets.py
+++ b/djangocms_text/widgets.py
@@ -80,6 +80,13 @@ class TextEditorWidget(forms.Textarea):
         body_css_classes: A string for CSS classes to be attached to the editor body.
     """
 
+    widget_css = (
+        "djangocms_text/css/cms.text.css",
+        "djangocms_text/css/cms.normalize.css",
+    )
+
+    widget_js = ("djangocms_text/bundles/bundle.editor.min.js",)
+
     @property
     def media(self):
         rte_css = self.rte_config.css.get("all", ())
@@ -89,13 +96,12 @@ class TextEditorWidget(forms.Textarea):
             css={
                 **self.rte_config.css,
                 "all": (
-                    "djangocms_text/css/cms.text.css",
-                    "djangocms_text/css/cms.normalize.css",
+                    *self.widget_css,
                     *rte_css,
                 ),
             },
             js=(
-                "djangocms_text/bundles/bundle.editor.min.js",
+                *self.widget_js,
                 *self.rte_config.js,
             ),
         )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Eliminate an obsolete admin JavaScript bundle from the ckeditor4 configuration to prevent unnecessary loading.

@corentinbettiol
