### PR TITLE
Bump version to 0.9.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+0.9.7 (07-05-2026)
+==================
+
+* feat: Allow dynamic extensions of tiptap editor by @fsbraun in https://github.com/django-cms/djangocms-text/pull/167
+* fix: Create dblClick guard to capture dblClick + drag by @fsbraun in https://github.com/django-cms/djangocms-text/pull/164
+* fix: Clamp toolbar to the viewport by @fsbraun in https://github.com/django-cms/djangocms-text/pull/165
+* fix: Doubleclick handler swallowed dbl clicks on child plugins by @fsbraun in https://github.com/django-cms/djangocms-text/pull/169
+* fix: Resize dialog on Safari by @fsbraun in https://github.com/django-cms/djangocms-text/pull/171
+* fix: Remove unused JavaScript file from ckeditor4 config by @fsbraun in https://github.com/django-cms/djangocms-text/pull/174
+
 0.9.6 (09-04-2026)
 ==================
 

--- a/djangocms_text/__init__.py
+++ b/djangocms_text/__init__.py
@@ -16,4 +16,4 @@ Release logic:
 10. Github actions will publish the new package to pypi
 """
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update library version constant to 0.9.7 to prepare for publishing the new release.