### PR TITLE
fix: support ordered list display in plugin via normalize.css

### DIFF
--- a/djangocms_text/static/djangocms_text/css/cms.normalize.css
+++ b/djangocms_text/static/djangocms_text/css/cms.normalize.css
@@ -77,11 +77,14 @@ body.change-form .cms-editor-inline-wrapper.fixed {
         border: none;
         border-top: 1px solid var(--dca-gray-lighter);
     }
-    ul {
+    ul, ol {
         display: block;
         list-style: disc outside none;
         margin: 0;
         padding: 0 0 0 40px;
+    }
+    ol {
+        list-style: decimal outside none;
     }
     li {
         list-style: inherit;


### PR DESCRIPTION
@fsbraun: when used with tiptap as main editor with NumberedList i need a custom fix to display ordered lists in plugins. Likely when editors/devs edit this inline in classic "mindfull" cms this fix is not strictly necessary as a framework like bootstrap covers this already. In a more barebone situation we need this, i think.

## Summary by Sourcery

Bug Fixes:
- Fix missing default styling for ordered lists in the inline editor so numbered lists display properly.