### PR TITLE
fix: Neighboring CSS contexts could cover block toolbar

### DIFF
--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -6,6 +6,15 @@ html.cms-toolbar-expanded {
 
 .cms-editor-inline-wrapper {
     --tiptap-ease: 100ms;
+    /* Lift the active editor above neighbouring columns so the block
+       toolbar (which paints outside the editor's bounds) is not covered
+       by sibling stacking contexts. */
+    &:has(.ProseMirror-focused),
+    &.has-form-dialog,
+    &.has-focused-editor {
+        z-index: 10;
+        isolation: isolate;
+    }
     .ProseMirror-focused [role="menubar"],
     &.has-form-dialog [role="menubar"],
     &.has-focused-editor [role="menubar"] {


### PR DESCRIPTION

## Summary by Sourcery

Bug Fixes:
- Prevent neighboring stacking contexts from covering the block toolbar of the focused inline editor.
- fixes #177
