### PR TITLE
fix: Block toolbar item clicks sometimes were lost

### DIFF
--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -305,6 +305,16 @@ html.cms-toolbar-expanded {
     }
 
     /* Block toolbar */
+    /* Keep the toolbar and its open dropdown visible even if the editor
+       momentarily loses focus, so clicks on the dropdown are not lost */
+    .cms-block-toolbar.show {
+        visibility: visible;
+        opacity: 1;
+        .cms-block-dropdown {
+            visibility: visible;
+            opacity: 1;
+        }
+    }
     .ProseMirror-focused .cms-block-toolbar, &.has-form-dialog .cms-block-toolbar {
         /* show toolbar if editor is focused or form dialog is open */
         visibility: visible;

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -124,6 +124,11 @@ function _createBlockToolbar(editor, blockToolbar) {
         // mousedown blurs the editor, whose focus-driven CSS hides the toolbar
         // before the click event can fire. The drag handle (first child) must
         // keep its default behavior so dragstart still works.
+        // Only intercept primary-button clicks so middle-click, context menus,
+        // and other non-primary interactions continue to work as expected.
+        if (event.button !== 0) {
+            return;
+        }
         if (toolbar.lastElementChild?.contains(event.target)) {
             event.preventDefault();
         }

--- a/private/js/tiptap_plugins/cms.toolbar.js
+++ b/private/js/tiptap_plugins/cms.toolbar.js
@@ -62,6 +62,11 @@ function _createBlockToolbarPlugin(editor) {
                 click (view, event) {
                     const blockToolbar = editor.options?.blockToolbar;
                     if (blockToolbar?.contains(event.target)) {
+                        // Refocus the editor so the focus-driven CSS keeps the
+                        // toolbar visible and the blur handler does not save
+                        if (!editor.isFocused) {
+                            editor.commands.focus();
+                        }
                         if (blockToolbar.lastElementChild?.contains(event.target)) {
                             // clicked somewhere in dropdown?
                             _handleToolbarClick(event, editor);
@@ -114,6 +119,15 @@ function _createBlockToolbar(editor, blockToolbar) {
     toolbar.innerHTML = `${_drag_icon}<div class="cms-block-dropdown">${_populateToolbar(editor, blockToolbar, 'block')}</div>`;
 
     toolbar.draggable = true;
+    toolbar.addEventListener('mousedown', (event) => {
+        // Keep the editor focused when clicking dropdown items: an unprevented
+        // mousedown blurs the editor, whose focus-driven CSS hides the toolbar
+        // before the click event can fire. The drag handle (first child) must
+        // keep its default behavior so dragstart still works.
+        if (toolbar.lastElementChild?.contains(event.target)) {
+            event.preventDefault();
+        }
+    });
     toolbar.addEventListener("dragstart", (event) => {
         toolbar.classList.remove('show');
         const start = parseInt(editor.options.blockToolbar.dataset.start);


### PR DESCRIPTION
## Summary by Sourcery

Ensure block toolbar dropdown interactions are not lost when the editor temporarily loses focus by keeping the toolbar visible and preventing focus-blurring mouse events.

Bug Fixes:
- Prevent block toolbar dropdown clicks from being lost when the editor blurs during interaction.

Enhancements:
- Maintain editor focus and toolbar visibility during block toolbar dropdown interactions through updated event handling and CSS visibility rules.