### PR TITLE
fix: p, and h1...h6 were nested by block toolbar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,9 @@ Example TipTap configuration (matches the defaults):
         ],
         "blockStyles": [],
         # Block styles menu, e.g., for paragraphs; empty by default.
-        # Example: [{"name": "Lead", "element": "div", "attributes": {"class": "lead"}}]
+        # Example: [{"name": "Lead", "element": "p", "attributes": {"class": "lead"}}]
+        # Styles for p and h1-h6 set the attributes on the element itself;
+        # styles for container elements (div, section, ...) wrap the selected blocks.
         "textColors": {  # Colors offered for the text color menu - the keys are CSS classes
             'text-primary': {"name": "Primary"},
             'text-secondary': {"name": "Secondary"},

--- a/private/css/cms.toolbar.css
+++ b/private/css/cms.toolbar.css
@@ -8,12 +8,15 @@ html.cms-toolbar-expanded {
     --tiptap-ease: 100ms;
     /* Lift the active editor above neighbouring columns so the block
        toolbar (which paints outside the editor's bounds) is not covered
-       by sibling stacking contexts. */
+       by sibling stacking contexts. Note: do NOT add `isolation: isolate`
+       here — it creates a stacking context that traps the block toolbar's
+       own high z-index inside the wrapper, so it would only compete with
+       siblings at z-index:10 and could still be covered (and clicks lost
+       the moment focus drops). */
     &:has(.ProseMirror-focused),
     &.has-form-dialog,
     &.has-focused-editor {
         z-index: 10;
-        isolation: isolate;
     }
     .ProseMirror-focused [role="menubar"],
     &.has-form-dialog [role="menubar"],

--- a/private/js/cms.tiptap.js
+++ b/private/js/cms.tiptap.js
@@ -243,7 +243,16 @@ class CMSTipTapPlugin {
             const extensions = [
                 ...filterExtensions(options.extensions, toolbarItems),
                 ...CmsTiptapRegistry.buildExtensions(),
-            ];
+            ].map((ext) => {
+                // blockstyle registers global attributes at schema-build time,
+                // before editor options are available - pass styles as
+                // extension options
+                const name = ext.name || ext?.config?.name;
+                if (name === 'blockstyle' && options.blockStyles) {
+                    return ext.configure({styles: options.blockStyles});
+                }
+                return ext;
+            });
 
             const firstInput = document.querySelector('textarea, input:not([type="hidden"]), select');
             const shouldAutofocus = el.tagName === 'TEXTAREA' && firstInput === el;

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -170,6 +170,28 @@ function renderStyleMenu(styles, editor, defaultTag = 'span') {
     return menu.join('');
 }
 
+/**
+ * Block elements whose HTML content model is phrasing content only and which
+ * map to an existing textblock node in the schema. Styles targeting these
+ * elements must not use the blockstyle wrapper node: wrapping would nest
+ * block content inside them (e.g. <p> inside <p>), which is invalid HTML
+ * that browsers split apart when re-parsing. Such styles are applied as
+ * attributes on the existing node instead.
+ */
+const styleableTextblocks = {
+    p: {type: 'paragraph', attrs: {}},
+    h1: {type: 'heading', attrs: {level: 1}},
+    h2: {type: 'heading', attrs: {level: 2}},
+    h3: {type: 'heading', attrs: {level: 3}},
+    h4: {type: 'heading', attrs: {level: 4}},
+    h5: {type: 'heading', attrs: {level: 5}},
+    h6: {type: 'heading', attrs: {level: 6}},
+};
+
+function textblockStyle(style) {
+    return (style.element && styleableTextblocks[style.element.toLowerCase()]) || null;
+}
+
 function validateAttributes(node, styleAttributes) {
     if (!styleAttributes) {
         return true;
@@ -235,7 +257,12 @@ const Style = {
     },
 
     parseHTML() {
-        const styles = resolveStyles(this);
+        let styles = resolveStyles(this);
+        if (this.name === 'blockstyle') {
+            // Textblock styles (p, h1-h6) are handled as attributes on the
+            // existing nodes via addGlobalAttributes, not as wrapper nodes
+            styles = styles.filter(style => !textblockStyle(style));
+        }
 
        return styles.map(style => {
            return {
@@ -357,12 +384,52 @@ const BlockStyle = Node.create({
     defaultTag: 'div',
     ...Style,
 
+    addGlobalAttributes() {
+        // Styles targeting textblock elements are stored as a `blockStyle`
+        // attribute on the paragraph/heading node itself. Editor-level
+        // blockStyles must be passed in as extension options (see
+        // cms.tiptap.js) because this hook runs at schema-build time,
+        // before an editor instance is available.
+        const styles = (this.options.styles || []).filter(style => textblockStyle(style));
+        return [{
+            types: ['paragraph', 'heading'],
+            attributes: {
+                blockStyle: {
+                    default: null,
+                    parseHTML: element => {
+                        for (const style of styles) {
+                            if (element.tagName === style.element.toUpperCase() &&
+                                    validateAttributes(element, style.attributes)) {
+                                return style.attributes || null;
+                            }
+                        }
+                        return null;
+                    },
+                    renderHTML: attributes => attributes.blockStyle || {},
+                },
+            },
+        }];
+    },
+
     addCommands() {
         return {
-            toggleBlockStyle: (id) => ({commands}) => {
+            toggleBlockStyle: (id) => ({editor, commands}) => {
                 const style = resolveStyles(this)[id];
                 if (!style) {
                     return false;
+                }
+                const textblock = textblockStyle(style);
+                if (textblock) {
+                    if (!editor.schema.nodes[textblock.type]) {
+                        return false;
+                    }
+                    if (commands.activeBlockStyle(id)) {
+                        return commands.updateAttributes(textblock.type, {blockStyle: null});
+                    }
+                    return commands.setNode(textblock.type, {
+                        ...textblock.attrs,
+                        blockStyle: style.attributes || null,
+                    });
                 }
                 return commands.toggleWrap(this.name, {
                         tag: style.element,
@@ -371,7 +438,18 @@ const BlockStyle = Node.create({
             },
             activeBlockStyle: (id) => ({editor}) => {
                 const style = resolveStyles(this)[id];
-                return style && editor.isActive(this.name, {
+                if (!style) {
+                    return false;
+                }
+                const textblock = textblockStyle(style);
+                if (textblock) {
+                    if (!editor.isActive(textblock.type, textblock.attrs)) {
+                        return false;
+                    }
+                    const active = editor.getAttributes(textblock.type).blockStyle;
+                    return JSON.stringify(active || null) === JSON.stringify(style.attributes || null);
+                }
+                return editor.isActive(this.name, {
                     tag: style.element,
                     attributes: style.attributes,
                 });

--- a/private/js/tiptap_plugins/cms.styles.js
+++ b/private/js/tiptap_plugins/cms.styles.js
@@ -426,7 +426,9 @@ const BlockStyle = Node.create({
                     if (commands.activeBlockStyle(id)) {
                         return commands.updateAttributes(textblock.type, {blockStyle: null});
                     }
+                    const currentAttrs = editor.getAttributes(textblock.type) || {};
                     return commands.setNode(textblock.type, {
+                        ...currentAttrs,
                         ...textblock.attrs,
                         blockStyle: style.attributes || null,
                     });

--- a/tests/js/cms.styles.test.js
+++ b/tests/js/cms.styles.test.js
@@ -168,6 +168,81 @@ describe('Tiptap style extensions', () => {
             expect(editor.can().toggleBlockStyle(0)).toBe(false);
         });
 
+        it('round-trips a paragraph block style without nesting or splitting', () => {
+            const content = '<p class="lead">Lead text</p><p>Normal text</p>';
+            const editor = createEditorWithContent('test-block-lead-1', content, {
+                toolbar: [['Bold', 'BlockStyles']],
+                blockStyles: [
+                    { name: 'Lead', element: 'p', attributes: { class: 'lead' } },
+                ],
+            });
+
+            const html = editor.getHTML();
+            expect(html).toBe('<p class="lead">Lead text</p><p>Normal text</p>');
+            // No wrapper node: the doc contains two plain paragraphs
+            expect(editor.state.doc.childCount).toBe(2);
+            expect(editor.state.doc.child(0).type.name).toBe('paragraph');
+        });
+
+        it('strips unconfigured classes from paragraphs', () => {
+            const content = '<p class="random">Some text</p>';
+            const editor = createEditorWithContent('test-block-lead-2', content, {
+                toolbar: [['Bold', 'BlockStyles']],
+                blockStyles: [
+                    { name: 'Lead', element: 'p', attributes: { class: 'lead' } },
+                ],
+            });
+
+            const html = editor.getHTML();
+            expect(html).not.toContain('random');
+            expect(html).toContain('Some text');
+        });
+
+        it('applies a paragraph block style as an attribute via toggleBlockStyle', () => {
+            const editor = createEditorWithContent('test-block-lead-3', '<p>Some text</p>', {
+                toolbar: [['Bold', 'BlockStyles']],
+                blockStyles: [
+                    { name: 'Lead', element: 'p', attributes: { class: 'lead' } },
+                ],
+            });
+
+            editor.commands.selectAll();
+            editor.commands.toggleBlockStyle(0);
+            expect(editor.getHTML()).toBe('<p class="lead">Some text</p>');
+            expect(editor.commands.activeBlockStyle(0)).toBe(true);
+
+            // Toggling again removes the style
+            editor.commands.toggleBlockStyle(0);
+            expect(editor.getHTML()).toBe('<p>Some text</p>');
+            expect(editor.commands.activeBlockStyle(0)).toBe(false);
+        });
+
+        it('round-trips a heading block style', () => {
+            const content = '<h2 class="display-2">Big heading</h2>';
+            const editor = createEditorWithContent('test-block-heading', content, {
+                toolbar: [['Heading2', 'BlockStyles']],
+                blockStyles: [
+                    { name: 'Display', element: 'h2', attributes: { class: 'display-2' } },
+                ],
+            });
+
+            expect(editor.getHTML()).toBe('<h2 class="display-2">Big heading</h2>');
+        });
+
+        it('does not apply a heading style to a paragraph with the same class', () => {
+            const content = '<p class="display-2">Not a heading</p>';
+            const editor = createEditorWithContent('test-block-mismatch', content, {
+                toolbar: [['Heading2', 'BlockStyles']],
+                blockStyles: [
+                    { name: 'Display', element: 'h2', attributes: { class: 'display-2' } },
+                ],
+            });
+
+            const html = editor.getHTML();
+            expect(html).not.toContain('display-2');
+            expect(html).toContain('Not a heading');
+        });
+
         it('strips all block styles when none are configured', () => {
             const content = '<div class="special"><p>wrapped</p></div><p>normal</p>';
             const editor = createEditorWithContent('test-block-2', content, {


### PR DESCRIPTION
## Summary by Sourcery

Handle block styles for paragraph and heading nodes without creating nested block wrappers, and ensure editor configuration passes block style definitions into the blockstyle extension.

New Features:
- Support applying block styles directly to paragraph and heading textblock nodes via a dedicated blockStyle attribute instead of wrapper nodes.

Bug Fixes:
- Prevent invalid nested block structures when styling p and h1–h6 elements via the block style toolbar, preserving correct HTML on round-trips.
- Ensure heading-specific block styles are not incorrectly inferred from paragraphs that merely share the same CSS class.
- Strip unconfigured or mismatched classes from paragraphs and headings when parsing content to avoid stale styling.

Enhancements:
- Filter textblock-targeting styles out of the blockstyle wrapper node parsing so they are handled purely as attributes.
- Pass editor-level blockStyles into the blockstyle extension at schema-build time through extension configuration.

Tests:
- Add integration tests covering paragraph and heading block style round-trips, toggling via commands, class stripping, and heading/paragraph mismatch behaviour.