### PR TITLE
fix: In RTL languages the modal was mispositioned

### DIFF
--- a/djangocms_text/static/djangocms_text/css/cms.text.css
+++ b/djangocms_text/static/djangocms_text/css/cms.text.css
@@ -23,7 +23,7 @@
 
 #cms-top dialog.cms-dialog {
     padding: 0;
-    margin: 0;
+    margin: 0;  /* Resets some values from django CMS core */
     top: 50%;
     inset-inline-start: 50%;
     inset-inline-end: unset;
@@ -75,12 +75,19 @@
     .cms-modal-resize:hover {
         opacity: 1;
     }
-    /* RTL: `inset-inline-start` resolves to `right`, pinning the dialog's
-       right edge to the centre line, so the centering translate flips sign
-       (transform is physical and does not mirror). Nested so it outranks
-       the base `#cms-top …` rule (a standalone `[dir="rtl"]` selector
-       would have lower specificity and never apply). */
+    /* RTL: mirror the resize handle and flip the centering translate.
+       Nested under the `#cms-top dialog.cms-dialog` selector so it
+       outranks the base rule (the previous standalone `[dir="rtl"]`
+       selector had lower specificity than `#cms-top …` and never
+       applied). */
     &:dir(rtl) {
+        /* `inset-inline-start: 50%` resolves to `right: 50%` in RTL, so it
+           pins the dialog's *right* edge to the centre line instead of the
+           left edge. `transform` is physical (does not mirror), so the
+           centering term flips sign: +50% pushes the box back to centre.
+           The base rule's `+250px` is a physical nudge needed only for the
+           left-anchored (LTR) case; right-anchored RTL needs no offset
+           (verified empirically — see PR discussion). */
         --cms-dialog-tx: 50%;
         .cms-modal-resize {
             cursor: nesw-resize;

--- a/djangocms_text/static/djangocms_text/css/cms.text.css
+++ b/djangocms_text/static/djangocms_text/css/cms.text.css
@@ -23,11 +23,16 @@
 
 #cms-top dialog.cms-dialog {
     padding: 0;
+    margin: 0;
     top: 50%;
-    left: 50%;
     inset-inline-start: 50%;
     inset-inline-end: unset;
-    transform: translate(calc(-50% + 250px), calc(-50% + 121px));
+    /* Anchor by the inline-start edge only (no physical `left`), so the
+       dialog is positioned by `left` in LTR and `right` in RTL without
+       being over-constrained. The horizontal translate is mirrored for
+       RTL via --cms-dialog-tx below. */
+    --cms-dialog-tx: -50%;
+    transform: translate(var(--cms-dialog-tx), calc(-50% + 21px));
     width: 32rem;
     height: 24rem;
     min-height: 16rem;
@@ -39,7 +44,7 @@
     }
     .cms-modal-resize {
         position: absolute;
-        right: 0;
+        inset-inline-end: 0;
         bottom: 0;
         width: 24px;
         height: 24px;
@@ -70,11 +75,25 @@
     .cms-modal-resize:hover {
         opacity: 1;
     }
-}
-
-[dir="rtl"] dialog.cms-dialog {
-    inset-inline-start: unset;
-    inset-inline-end: 50%;
+    /* RTL: mirror the resize handle and flip the centering translate.
+       Nested under the `#cms-top dialog.cms-dialog` selector so it
+       outranks the base rule (the previous standalone `[dir="rtl"]`
+       selector had lower specificity than `#cms-top …` and never
+       applied). */
+    &:dir(rtl) {
+        /* `inset-inline-start: 50%` resolves to `right: 50%` in RTL, so it
+           pins the dialog's *right* edge to the centre line instead of the
+           left edge. `transform` is physical (does not mirror), so the
+           centering term flips sign: +50% pushes the box back to centre.
+           The base rule's `+250px` is a physical nudge needed only for the
+           left-anchored (LTR) case; right-anchored RTL needs no offset
+           (verified empirically — see PR discussion). */
+        --cms-dialog-tx: 50%;
+        .cms-modal-resize {
+            cursor: nesw-resize;
+            transform: scaleX(-1);  /* flip handle to the bottom-start corner */
+        }
+    }
 }
 
 dialog.cms-form-dialog, .cms-editor-inline-wrapper .cms-block-dropdown {

--- a/djangocms_text/static/djangocms_text/css/cms.text.css
+++ b/djangocms_text/static/djangocms_text/css/cms.text.css
@@ -30,7 +30,7 @@
     /* Anchor by the inline-start edge only (no physical `left`), so the
        dialog is positioned by `left` in LTR and `right` in RTL without
        being over-constrained. The horizontal translate is mirrored for
-       RTL via --cms-dialog-tx below. */
+       RTL via --cms-dialog-tx below. 21px give a small offset down. */
     --cms-dialog-tx: -50%;
     transform: translate(var(--cms-dialog-tx), calc(-50% + 21px));
     width: 32rem;

--- a/djangocms_text/static/djangocms_text/css/cms.text.css
+++ b/djangocms_text/static/djangocms_text/css/cms.text.css
@@ -27,10 +27,10 @@
     top: 50%;
     inset-inline-start: 50%;
     inset-inline-end: unset;
-    /* Anchor by the inline-start edge only (no physical `left`), so the
-       dialog is positioned by `left` in LTR and `right` in RTL without
-       being over-constrained. The horizontal translate is mirrored for
-       RTL via --cms-dialog-tx below. 21px give a small offset down. */
+    /* Anchor by inline-start only (no physical `left`) so the dialog is
+       positioned by `left` in LTR and `right` in RTL without being
+       over-constrained. The translate is mirrored for RTL via
+       --cms-dialog-tx; the 21px nudges it slightly below centre. */
     --cms-dialog-tx: -50%;
     transform: translate(var(--cms-dialog-tx), calc(-50% + 21px));
     width: 32rem;
@@ -75,19 +75,12 @@
     .cms-modal-resize:hover {
         opacity: 1;
     }
-    /* RTL: mirror the resize handle and flip the centering translate.
-       Nested under the `#cms-top dialog.cms-dialog` selector so it
-       outranks the base rule (the previous standalone `[dir="rtl"]`
-       selector had lower specificity than `#cms-top …` and never
-       applied). */
+    /* RTL: `inset-inline-start` resolves to `right`, pinning the dialog's
+       right edge to the centre line, so the centering translate flips sign
+       (transform is physical and does not mirror). Nested so it outranks
+       the base `#cms-top …` rule (a standalone `[dir="rtl"]` selector
+       would have lower specificity and never apply). */
     &:dir(rtl) {
-        /* `inset-inline-start: 50%` resolves to `right: 50%` in RTL, so it
-           pins the dialog's *right* edge to the centre line instead of the
-           left edge. `transform` is physical (does not mirror), so the
-           centering term flips sign: +50% pushes the box back to centre.
-           The base rule's `+250px` is a physical nudge needed only for the
-           left-anchored (LTR) case; right-anchored RTL needs no offset
-           (verified empirically — see PR discussion). */
         --cms-dialog-tx: 50%;
         .cms-modal-resize {
             cursor: nesw-resize;

--- a/private/js/cms.dialog.js
+++ b/private/js/cms.dialog.js
@@ -191,6 +191,40 @@ class CmsDialog {
     }
 
     /**
+     * Whether the dialog is laid out right-to-left. In RTL the dialog is
+     * anchored by its `right` edge (see the `inset-inline-start` rule in
+     * cms.text.css), so drag/resize move along `right` and invert the
+     * horizontal delta.
+     *
+     * @return {boolean}
+     */
+    isRtl() {
+        return getComputedStyle(this.dialog).direction === 'rtl';
+    }
+
+    /**
+     * The physical inset property the dialog is anchored by (`right` in RTL,
+     * `left` otherwise).
+     *
+     * @return {string}
+     */
+    inlineProp() {
+        return this.isRtl() ? 'right' : 'left';
+    }
+
+    /**
+     * Pointer movement along the inline axis, mirrored for RTL so a positive
+     * value always grows towards the inline-end edge.
+     *
+     * @param {number} firstX - The pointer's starting page X.
+     * @param {number} currentX - The pointer's current page X.
+     * @return {number}
+     */
+    inlineDelta(firstX, currentX) {
+        return this.isRtl() ? firstX - currentX : currentX - firstX;
+    }
+
+    /**
      * Allows dragging the dialog based on the user's mouse movements.
      *
      * @param {Event} event - The mouse event that triggers the drag.
@@ -200,19 +234,14 @@ class CmsDialog {
             return;
         }
         event.preventDefault();
-        // In RTL the dialog is anchored by its `right` edge (see the
-        // `inset-inline-start` rule in cms.text.css), so we move it along
-        // `right` and invert the horizontal delta.
-        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
-        const inlineProp = rtl ? 'right' : 'left';
+        const inlineProp = this.inlineProp();
         const firstX = event.pageX;
         const firstY = event.pageY;
         const initialX = parseInt(getComputedStyle(this.dialog)[inlineProp]);
         const initialY = parseInt(getComputedStyle(this.dialog).top);
 
         const dragIt = (e) => {
-            const dx = rtl ? firstX - e.pageX : e.pageX - firstX;
-            this.dialog.style[inlineProp] = initialX + dx + 'px';
+            this.dialog.style[inlineProp] = initialX + this.inlineDelta(firstX, e.pageX) + 'px';
             this.dialog.style.top = initialY + e.pageY - firstY + 'px';
         };
         const Window = window.parent || window;
@@ -230,8 +259,7 @@ class CmsDialog {
     swipeDialog(event) {
         event.preventDefault();
 
-        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
-        const inlineProp = rtl ? 'right' : 'left';
+        const inlineProp = this.inlineProp();
         const firstX = event.pageX;
         const firstY = event.pageY;
         const initialX = parseInt(getComputedStyle(this.dialog)[inlineProp]);
@@ -239,8 +267,7 @@ class CmsDialog {
 
         const swipeIt = (e) => {
             const contact = e.touches;
-            const dx = rtl ? firstX - contact[0].pageX : contact[0].pageX - firstX;
-            this.dialog.style[inlineProp] = initialX + dx + 'px';
+            this.dialog.style[inlineProp] = initialX + this.inlineDelta(firstX, contact[0].pageX) + 'px';
             this.dialog.style.top = initialY + contact[0].pageY - firstY + 'px';
         };
 
@@ -264,18 +291,15 @@ class CmsDialog {
         }
         event.preventDefault();
         event.stopPropagation();
-        // In RTL the dialog grows towards the inline-start (left) edge and
-        // the handle sits in the bottom-left corner, so the horizontal
-        // delta is inverted.
-        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
+        // In RTL the handle sits in the bottom-left corner and the dialog
+        // grows towards the inline-start edge, so the width delta is mirrored.
         const firstX = event.pageX;
         const firstY = event.pageY;
         const initialW = parseInt(getComputedStyle(this.dialog).width);
         const initialH = parseInt(getComputedStyle(this.dialog).height);
 
         const resizeIt = (e) => {
-            const dw = rtl ? firstX - e.pageX : e.pageX - firstX;
-            this.dialog.style.width = initialW + dw + 'px';
+            this.dialog.style.width = initialW + this.inlineDelta(firstX, e.pageX) + 'px';
             this.dialog.style.height = initialH + e.pageY - firstY + 'px';
         };
         const Window = window.parent || window;
@@ -294,7 +318,6 @@ class CmsDialog {
     touchResizeDialog(event) {
         event.preventDefault();
         event.stopPropagation();
-        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
         const firstX = event.touches[0].pageX;
         const firstY = event.touches[0].pageY;
         const initialW = parseInt(getComputedStyle(this.dialog).width);
@@ -302,8 +325,7 @@ class CmsDialog {
 
         const resizeIt = (e) => {
             const contact = e.touches;
-            const dw = rtl ? firstX - contact[0].pageX : contact[0].pageX - firstX;
-            this.dialog.style.width = initialW + dw + 'px';
+            this.dialog.style.width = initialW + this.inlineDelta(firstX, contact[0].pageX) + 'px';
             this.dialog.style.height = initialH + contact[0].pageY - firstY + 'px';
         };
         const Window = window.parent || window;

--- a/private/js/cms.dialog.js
+++ b/private/js/cms.dialog.js
@@ -200,13 +200,19 @@ class CmsDialog {
             return;
         }
         event.preventDefault();
+        // In RTL the dialog is anchored by its `right` edge (see the
+        // `inset-inline-start` rule in cms.text.css), so we move it along
+        // `right` and invert the horizontal delta.
+        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
+        const inlineProp = rtl ? 'right' : 'left';
         const firstX = event.pageX;
         const firstY = event.pageY;
-        const initialX = parseInt(getComputedStyle(this.dialog).left);
+        const initialX = parseInt(getComputedStyle(this.dialog)[inlineProp]);
         const initialY = parseInt(getComputedStyle(this.dialog).top);
 
         const dragIt = (e) => {
-            this.dialog.style.left = initialX + e.pageX - firstX + 'px';
+            const dx = rtl ? firstX - e.pageX : e.pageX - firstX;
+            this.dialog.style[inlineProp] = initialX + dx + 'px';
             this.dialog.style.top = initialY + e.pageY - firstY + 'px';
         };
         const Window = window.parent || window;
@@ -224,14 +230,17 @@ class CmsDialog {
     swipeDialog(event) {
         event.preventDefault();
 
+        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
+        const inlineProp = rtl ? 'right' : 'left';
         const firstX = event.pageX;
         const firstY = event.pageY;
-        const initialX = parseInt(getComputedStyle(this.dialog).left);
+        const initialX = parseInt(getComputedStyle(this.dialog)[inlineProp]);
         const initialY = parseInt(getComputedStyle(this.dialog).top);
 
         const swipeIt = (e) => {
             const contact = e.touches;
-            this.dialog.style.left = initialX + contact[0].pageX - firstX + 'px';
+            const dx = rtl ? firstX - contact[0].pageX : contact[0].pageX - firstX;
+            this.dialog.style[inlineProp] = initialX + dx + 'px';
             this.dialog.style.top = initialY + contact[0].pageY - firstY + 'px';
         };
 
@@ -255,13 +264,18 @@ class CmsDialog {
         }
         event.preventDefault();
         event.stopPropagation();
+        // In RTL the dialog grows towards the inline-start (left) edge and
+        // the handle sits in the bottom-left corner, so the horizontal
+        // delta is inverted.
+        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
         const firstX = event.pageX;
         const firstY = event.pageY;
         const initialW = parseInt(getComputedStyle(this.dialog).width);
         const initialH = parseInt(getComputedStyle(this.dialog).height);
 
         const resizeIt = (e) => {
-            this.dialog.style.width = initialW + e.pageX - firstX + 'px';
+            const dw = rtl ? firstX - e.pageX : e.pageX - firstX;
+            this.dialog.style.width = initialW + dw + 'px';
             this.dialog.style.height = initialH + e.pageY - firstY + 'px';
         };
         const Window = window.parent || window;
@@ -280,6 +294,7 @@ class CmsDialog {
     touchResizeDialog(event) {
         event.preventDefault();
         event.stopPropagation();
+        const rtl = getComputedStyle(this.dialog).direction === 'rtl';
         const firstX = event.touches[0].pageX;
         const firstY = event.touches[0].pageY;
         const initialW = parseInt(getComputedStyle(this.dialog).width);
@@ -287,7 +302,8 @@ class CmsDialog {
 
         const resizeIt = (e) => {
             const contact = e.touches;
-            this.dialog.style.width = initialW + contact[0].pageX - firstX + 'px';
+            const dw = rtl ? firstX - contact[0].pageX : contact[0].pageX - firstX;
+            this.dialog.style.width = initialW + dw + 'px';
             this.dialog.style.height = initialH + contact[0].pageY - firstY + 'px';
         };
         const Window = window.parent || window;

--- a/private/js/tiptap_plugins/cms.plugin.js
+++ b/private/js/tiptap_plugins/cms.plugin.js
@@ -1,6 +1,6 @@
 /* eslint-env es6 */
 /* jshint esversion: 9 */
-/* global document, window, console */
+/* global document, window, console, DOMParser */
 
 import { Node } from '@tiptap/core';
 import CmsDialog from "../cms.dialog.js";
@@ -18,6 +18,25 @@ function getNodeType(plugin) {
         return blockTags.includes(plugin.tagName) ? 'cmsBlockPlugin': 'cmsPlugin';
     }
     return 'cmsPlugin';
+}
+
+
+/**
+ * Turn a trusted SVG icon *string* (from the server-side plugin registry,
+ * never user input) into a DOM node without going through an `innerHTML`
+ * sink. The string is parsed as XML (`image/svg+xml`), which does not
+ * execute scripts, then the resulting <svg> element is imported.
+ *
+ * @param {string} svg - The SVG markup string.
+ * @return {SVGElement|null} - The imported <svg> node, or null if invalid.
+ */
+function svgStringToNode(svg) {
+    'use strict';
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    if (doc.querySelector('parsererror') || doc.documentElement.tagName.toLowerCase() !== 'svg') {
+        return null;
+    }
+    return document.importNode(doc.documentElement, true);
 }
 
 
@@ -230,8 +249,16 @@ const cmsPluginNodes = {
                     const pluginType = node.attrs.HTMLAttributes.type;
                     const installed = window.CMS_Editor?.getInstalledPlugins?.() || [];
                     const pluginDef = installed.find(p => p.value === pluginType);
-                    placeholder.innerHTML = pluginDef?.icon ||
-                        TiptapToolbar.CMSPlugins?.icon || pluginType || '';
+                    // Icons are trusted SVG strings from the plugin registry;
+                    // parse and append them as nodes rather than via innerHTML.
+                    // Fall back to the plugin type as plain text.
+                    const icon = pluginDef?.icon || TiptapToolbar.CMSPlugins?.icon;
+                    const iconNode = icon ? svgStringToNode(icon) : null;
+                    if (iconNode) {
+                        placeholder.appendChild(iconNode);
+                    } else {
+                        placeholder.textContent = pluginType || '';
+                    }
                     dom.appendChild(placeholder);
                 }
             });


### PR DESCRIPTION
## Summary by Sourcery

Fix modal positioning and resizing behavior for RTL languages by making dialog centering, dragging, swiping, and resize handles direction-aware.

Bug Fixes:
- Ensure dialogs are correctly centered in RTL layouts without conflicting left/right positioning.
- Fix drag and swipe interactions so dialogs move correctly when the page direction is RTL.
- Correct resize behavior in RTL so width adjustments follow the expected direction and the resize handle is mirrored appropriately.

Enhancements:
- Use logical CSS properties and a shared transform variable to unify LTR and RTL dialog positioning rules.