### PR TITLE
fix: Prevent stored XSS in HTMLField

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,12 @@ HTML sanitizer
 ``djangocms-text`` uses `nh3 <https://nh3.readthedocs.io/en/latest/>`_ to
 sanitize HTML, both for security and to enforce well-formed markup.
 Sanitization may strip tags useful for some use cases (e.g. ``iframe``).
+
+HTML is sanitized when it is written through Django's ORM. It is not sanitized
+again when read from the database; stored values are treated as trusted HTML.
+Code that writes directly to the database, bypassing the ORM, must therefore
+sanitize HTML before storing it.
+
 Customize allowed tags and attributes via ``TEXT_ADDITIONAL_ATTRIBUTES``::
 
     TEXT_ADDITIONAL_ATTRIBUTES = {

--- a/djangocms_text/cms_plugins.py
+++ b/djangocms_text/cms_plugins.py
@@ -512,7 +512,8 @@ class TextPlugin(CMSPluginBase):
         return HttpResponse(status=204)
 
     def get_available_urls(self, request):
-        if not (request.user.is_active and request.user.is_staff):
+        permission = f"{self.model._meta.app_label}.view_{self.model._meta.model_name}"
+        if not (request.user.is_active and request.user.is_staff and request.user.has_perm(permission)):
             raise PermissionDenied
 
         if request.GET.get("g"):

--- a/djangocms_text/fields.py
+++ b/djangocms_text/fields.py
@@ -7,6 +7,11 @@ from .html import clean_html, render_dynamic_attributes
 from .widgets import TextEditorWidget
 
 
+def sanitize_and_mark_safe(value):
+    """Sanitize HTML immediately before marking it safe for templates."""
+    return mark_safe(clean_html(value))
+
+
 class HTMLFormField(CharField):
     widget = TextEditorWidget
 
@@ -23,15 +28,11 @@ class HTMLFormField(CharField):
     def clean(self, value):
         value = super().clean(value)
         value = render_dynamic_attributes(value, admin_objects=False, remove_attr=False)
-        clean_value = clean_html(value)
-
         # We `mark_safe` here (as well as in the correct places) because Django
         # Parler cache's the value directly from the in-memory object as it
         # also stores the value in the database. So the cached version is never
         # processed by `from_db_value()`.
-        clean_value = mark_safe(clean_value)
-
-        return clean_value
+        return sanitize_and_mark_safe(value)
 
 
 class HTMLField(models.TextField):
@@ -47,6 +48,12 @@ class HTMLField(models.TextField):
             return value
         value = render_dynamic_attributes(value, admin_objects=False, remove_attr=False)
         return mark_safe(value)
+
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if value is None:
+            return value
+        return clean_html(value)
 
     def to_python(self, value):
         # We don't need to add mark_safe
@@ -72,5 +79,5 @@ class HTMLField(models.TextField):
         # This needs to be marked safe as well because the form field's
         # clean method is not called on model.full_clean()
         value = render_dynamic_attributes(value, admin_objects=False, remove_attr=False)
-        value = clean_html(super().clean(value, model_instance))
-        return mark_safe(value)
+        value = super().clean(value, model_instance)
+        return sanitize_and_mark_safe(value)

--- a/djangocms_text/html.py
+++ b/djangocms_text/html.py
@@ -17,6 +17,7 @@ from djangocms_text import settings
 
 
 dyn_attr_pattern = re.compile(r"<[^>]*data-cms-[^>]*>")
+image_data_pattern = re.compile(r'data:(?P<mime_type>[^"]*);(?P<encoding>[^"]*),(?P<data>[^"]*)')
 cms_additional_attributes = {
     "a": {"href", "target", "rel"},
     "cms-plugin": {"id", "title", "name", "alt", "render-plugin", "type"},
@@ -173,18 +174,15 @@ def get_data_from_db(models: dict, admin_objects: bool = False) -> dict:
     """
     result = {}
     for model, ids in models.items():
-        result[model] = {}
         try:
             DjangoModel = apps.get_model(*model.split(".")[:2])
             if admin_objects and hasattr(DjangoModel, "admin_manager"):
-                DjangoModel = DjangoModel.admin_manager
+                manager = DjangoModel.admin_manager
             else:
-                DjangoModel = DjangoModel.objects
-
-            for obj in DjangoModel.filter(id__in=ids):
-                result[model][obj.id] = obj
+                manager = DjangoModel.objects
+            result[model] = manager.in_bulk(ids)
         except Exception:
-            pass
+            result[model] = {}
     return result
 
 
@@ -238,7 +236,7 @@ def dynamic_src(elem: Element, obj: models.Model, attr: str, edit_mode: bool = F
     if hasattr(obj, "get_absolute_url"):
         target_value = obj.get_absolute_url()
         if target_value:
-            elem.attrib[attr] = obj.get_absolute_url()
+            elem.attrib[attr] = target_value
     if not target_value:
         elem.attrib["data-cms-error"] = "ref-not-found"
 
@@ -339,8 +337,7 @@ def extract_images(data, plugin):
         width = img.getAttribute("width")
         height = img.getAttribute("height")
         # extract the image data
-        data_re = re.compile(r'data:(?P<mime_type>[^"]*);(?P<encoding>[^"]*),(?P<data>[^"]*)')
-        m = data_re.search(src)
+        m = image_data_pattern.search(src)
         dr = m.groupdict()
         mime_type = dr["mime_type"]
         image_data = dr["data"]

--- a/djangocms_text/models.py
+++ b/djangocms_text/models.py
@@ -76,7 +76,14 @@ if apps.is_installed("cms"):
             self.body = plugin_tags_to_db(self.body)
 
         def save(self, *args, **kwargs):
-            super().save(*args, **kwargs)
+            adding = self._state.adding
+            original_body = self.body
+
+            # Embedded image plugins need a persisted parent. Existing text
+            # plugins can transform their body before their only write.
+            if adding:
+                super().save(*args, **kwargs)
+
             body = self.body
             body = extract_images(body, self)
             body = clean_html(body)
@@ -86,11 +93,14 @@ if apps.is_installed("cms"):
                 except (TypeError, CMSPlugin.DoesNotExist):
                     body = hyphenate(body)
             self.body = body
-            # no need to pass args or kwargs here
-            # this 2nd save() call is internal and should be
-            # fully managed by us.
-            # think of it as an update() vs save()
-            super().save(update_fields=("body",))
+
+            if adding:
+                if body != original_body:
+                    super().save(update_fields=("body",))
+            else:
+                if kwargs.get("update_fields") is not None:
+                    kwargs["update_fields"] = set(kwargs["update_fields"]) | {"body"}
+                super().save(*args, **kwargs)
 
         def clean_plugins(self):
             ids = self._get_inline_plugin_ids()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -35,6 +35,15 @@ class FieldTestCase(BaseTestCase):
         rendered = template.render(Context({"obj": text}))
         self.assertEqual(original, rendered)
 
+    def test_model_field_is_sanitized_on_orm_update(self):
+        text = SimpleText.objects.create(text=self.text_normal)
+        SimpleText.objects.filter(pk=text.pk).update(text=self.text_with_script)
+
+        text = SimpleText.objects.get(pk=text.pk)
+
+        self.assertIsInstance(text.text, SafeData)
+        self.assertEqual(text.text, self.text_normal)
+
     def test_model_field_sanitized(self):
         obj = SimpleText(text=self.text_normal)
         obj.full_clean()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,7 +1,9 @@
 from django.template import Context, Template
+from django.test import override_settings
 from django.utils.safestring import SafeData
 
 from djangocms_text.fields import HTMLField, HTMLFormField
+from djangocms_text.widgets import TextEditorWidget
 
 from .base import BaseTestCase
 from .test_app.forms import SimpleTextForm
@@ -12,6 +14,13 @@ class HtmlFieldTestCase(BaseTestCase):
     def test_html_form_field(self):
         html_field = HTMLFormField()
         self.assertTrue(isinstance(html_field.clean("some text"), SafeData))
+
+    @override_settings(TEST_TEXT_EDITOR={"toolbar": "HTMLField"})
+    def test_html_form_field_uses_configured_widget(self):
+        html_field = HTMLFormField(configuration="TEST_TEXT_EDITOR")
+
+        self.assertIsInstance(html_field.widget, TextEditorWidget)
+        self.assertEqual(html_field.widget.configuration["toolbar"], "HTMLField")
 
 
 class FieldTestCase(BaseTestCase):
@@ -27,6 +36,9 @@ class FieldTestCase(BaseTestCase):
 
     def test_model_field_preserves_none_when_preparing_for_database(self):
         self.assertIsNone(HTMLField().get_prep_value(None))
+
+    def test_model_field_preserves_none_when_loading_from_database(self):
+        self.assertIsNone(HTMLField().from_db_value(None, None, None))
 
     def test_model_field_text_is_safe(self):
         original = "Hello <h2>There</h2>"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,7 +1,7 @@
 from django.template import Context, Template
 from django.utils.safestring import SafeData
 
-from djangocms_text.fields import HTMLFormField
+from djangocms_text.fields import HTMLField, HTMLFormField
 
 from .base import BaseTestCase
 from .test_app.forms import SimpleTextForm
@@ -24,6 +24,9 @@ class FieldTestCase(BaseTestCase):
     text_with_script_escaped = (
         '<p>some non malicious text</p>&lt;script&gt;alert("Hello! I am an alert box!");&lt;/script&gt;'
     )
+
+    def test_model_field_preserves_none_when_preparing_for_database(self):
+        self.assertIsNone(HTMLField().get_prep_value(None))
 
     def test_model_field_text_is_safe(self):
         original = "Hello <h2>There</h2>"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -302,8 +302,8 @@ class DynamicAttributesTestCase(TestCase):
         mock_obj.url = None
         mock_obj.get_absolute_url.return_value = "/resolved.jpg"
         with _patch("djangocms_text.html.apps.get_model") as mock_get_model:
-            mock_get_model.return_value.objects.filter.return_value = [mock_obj]
             mock_obj.id = 7
+            mock_get_model.return_value.objects.in_bulk.return_value = {mock_obj.id: mock_obj}
             html_in = '<img src="/old.jpg" alt="cat" data-cms-src="app.model:7">'
             html_out = render_dynamic_attributes(html_in)
         self.assertIn('src="/resolved.jpg"', html_out)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -9,7 +9,14 @@ try:
     from lxml.etree import Element
 
     from djangocms_text import html, settings
-    from djangocms_text.html import NH3Parser, dynamic_href, dynamic_src, render_dynamic_attributes
+    from djangocms_text.html import (
+        NH3Parser,
+        dynamic_href,
+        dynamic_src,
+        get_data_from_db,
+        get_xpath,
+        render_dynamic_attributes,
+    )
 
     SKIP_CMS_TEST = False
 except ModuleNotFoundError:
@@ -256,6 +263,30 @@ class DynamicAttributesTestCase(TestCase):
         dynamic_src(elem, mock_obj, "src")
         self.assertEqual(elem.attrib["src"], "/test-url")
 
+    def test_dynamic_src_marks_missing_reference(self):
+        elem = Element("img")
+
+        dynamic_src(elem, None, "src")
+
+        self.assertEqual(elem.attrib["data-cms-error"], "ref-not-found")
+
+    def test_get_data_from_db_uses_admin_manager(self):
+        model = MagicMock()
+        expected = {1: MagicMock()}
+        model.admin_manager.in_bulk.return_value = expected
+
+        with patch("djangocms_text.html.apps.get_model", return_value=model):
+            result = get_data_from_db({"app.model": {1}}, admin_objects=True)
+
+        self.assertEqual(result, {"app.model": expected})
+        model.admin_manager.in_bulk.assert_called_once_with({1})
+
+    def test_get_data_from_db_handles_unknown_model(self):
+        with patch("djangocms_text.html.apps.get_model", side_effect=LookupError):
+            result = get_data_from_db({"unknown.model": {1}})
+
+        self.assertEqual(result, {"unknown.model": {}})
+
     def test_render_dynamic_attributes_changes_html(self):
         page = create_page("page", "page.html", language="en")
         html = f'<a data-cms-href="cms.page:{page.pk}">Link</a>'
@@ -286,6 +317,33 @@ class DynamicAttributesTestCase(TestCase):
 
         xpath = get_xpath({"data-cms-href": None, "data-cms-src": None})
         self.assertEqual(xpath, "//*[@data-cms-href] | //*[@data-cms-src]")
+
+    def test_get_xpath_handles_empty_pool(self):
+        self.assertEqual(get_xpath({}), "")
+
+    def test_render_dynamic_attributes_batches_repeated_models(self):
+        obj_one = MagicMock(id=1)
+        obj_one.get_absolute_url.return_value = "/one/"
+        obj_two = MagicMock(id=2)
+        obj_two.get_absolute_url.return_value = "/two/"
+
+        with patch("djangocms_text.html.apps.get_model") as mock_get_model:
+            mock_get_model.return_value.objects.in_bulk.return_value = {1: obj_one, 2: obj_two}
+            result = render_dynamic_attributes(
+                '<a data-cms-href="app.model:1">One</a><a data-cms-href="app.model:2">Two</a>'
+            )
+
+        mock_get_model.return_value.objects.in_bulk.assert_called_once_with({1, 2})
+        self.assertIn('href="/one/"', result)
+        self.assertIn('href="/two/"', result)
+
+    def test_render_dynamic_attributes_preserves_source_in_edit_mode(self):
+        result = render_dynamic_attributes(
+            '<a data-cms-href="invalid-reference">Link</a>', admin_objects=True, remove_attr=False
+        )
+
+        self.assertIn('data-cms-href="invalid-reference"', result)
+        self.assertIn('data-cms-error="ref-not-found"', result)
 
     def test_render_dynamic_attributes_resolves_data_cms_src(self):
         # Regression for the same get_xpath bug above: with both
@@ -336,3 +394,14 @@ class DjangoCMSPictureIntegrationTestCase(CMSTestCase):
                 'P8z/C/HgAGgwJ/lK3Q6wAAAABJRU5ErkJggg==">',
             )
             mock_save_image.assert_called_once()
+
+    def test_extract_images_returns_unchanged_html_without_embedded_images(self):
+        body = '<img src="https://example.com/image.png">'
+
+        self.assertEqual(html.extract_images(body, plugin=None), body)
+
+    def test_extract_images_returns_unchanged_html_when_disabled(self):
+        body = '<img src="data:image/png;base64,AAAA">'
+
+        with patch.object(settings, "TEXT_SAVE_IMAGE_FUNCTION", None):
+            self.assertEqual(html.extract_images(body, plugin=None), body)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
+from django.core.exceptions import PermissionDenied
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.template import RequestContext
@@ -1048,6 +1049,23 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
         ]
         self.assertEqual(len(text_writes), 1, text_writes)
 
+    def test_existing_safe_text_plugin_without_update_fields_is_written_once(self):
+        page = self.create_page("test page", template="page.html", language="en")
+        placeholder = self.get_placeholders(page, "en").get(slot="content")
+        plugin = add_plugin(placeholder, "TextPlugin", "en", body="Initial safe text")
+
+        with CaptureQueriesContext(connection) as queries:
+            plugin.body = "Updated safe text"
+            plugin.save()
+
+        text_table = connection.ops.quote_name(Text._meta.db_table)
+        text_writes = [
+            query["sql"]
+            for query in queries
+            if query["sql"].lstrip().upper().startswith(("INSERT", "UPDATE")) and text_table in query["sql"]
+        ]
+        self.assertEqual(len(text_writes), 1, text_writes)
+
     def test_new_unsafe_text_plugin_is_sanitized_with_follow_up_write(self):
         page = self.create_page("test page", template="page.html", language="en")
         placeholder = self.get_placeholders(page, "en").get(slot="content")
@@ -1089,6 +1107,31 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
             result = self.client.get(endpoint + "?q=test")
 
         self.assertEqual(result.status_code, 200)
+
+    def test_url_resolution_rejects_non_staff_and_inactive_users(self):
+        plugin_admin = TextPlugin()
+
+        for user in (
+            self._create_user("url-non-staff", is_staff=False),
+            self._create_user("url-inactive", is_staff=True),
+        ):
+            if user.username == "url-inactive":
+                user.is_active = False
+                user.save(update_fields={"is_active"})
+            request = self.get_request()
+            request.user = user
+
+            with self.assertRaises(PermissionDenied):
+                plugin_admin.get_available_urls(request)
+
+    def test_url_resolution_rejects_invalid_model(self):
+        endpoint = admin_reverse("djangocms_text_textplugin_get_available_urls")
+
+        with self.login_user_context(self.superuser):
+            result = self.client.get(endpoint + "?g=invalid.model:1")
+
+        self.assertEqual(result.status_code, 200)
+        self.assertIn("error", result.json())
 
     def test_failed_url_resolution(self):
         page = self.create_page("test page", template="page.html", language="en")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1039,6 +1039,21 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json()["url"], page.get_absolute_url())
 
+    def test_url_resolution_requires_view_text_permission(self):
+        endpoint = admin_reverse("djangocms_text_textplugin_get_available_urls")
+        staff_user = self._create_user("url-staff", is_staff=True, is_superuser=False)
+
+        with self.login_user_context(staff_user):
+            result = self.client.get(endpoint + "?q=test")
+
+        self.assertEqual(result.status_code, 403)
+
+        self._give_permission(staff_user, Text, "view")
+        with self.login_user_context(staff_user):
+            result = self.client.get(endpoint + "?q=test")
+
+        self.assertEqual(result.status_code, 200)
+
     def test_failed_url_resolution(self):
         page = self.create_page("test page", template="page.html", language="en")
         endpoint = admin_reverse("djangocms_text_textplugin_get_available_urls")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1048,6 +1048,23 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
         ]
         self.assertEqual(len(text_writes), 1, text_writes)
 
+    def test_new_unsafe_text_plugin_is_sanitized_with_follow_up_write(self):
+        page = self.create_page("test page", template="page.html", language="en")
+        placeholder = self.get_placeholders(page, "en").get(slot="content")
+        unsafe_body = '<p>Safe</p><script>alert("unsafe")</script>'
+
+        with CaptureQueriesContext(connection) as queries:
+            plugin = add_plugin(placeholder, "TextPlugin", "en", body=unsafe_body)
+
+        text_table = connection.ops.quote_name(Text._meta.db_table)
+        text_writes = [
+            query["sql"]
+            for query in queries
+            if query["sql"].lstrip().upper().startswith(("INSERT", "UPDATE")) and text_table in query["sql"]
+        ]
+        self.assertEqual(plugin.body, "<p>Safe</p>")
+        self.assertEqual(len(text_writes), 3, text_writes)
+
     def test_url_resolution(self):
         page = self.create_page("test page", template="page.html", language="en")
         endpoint = admin_reverse("djangocms_text_textplugin_get_available_urls")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1034,9 +1034,11 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
     def test_safe_text_plugin_body_is_written_once(self):
         page = self.create_page("test page", template="page.html", language="en")
         placeholder = self.get_placeholders(page, "en").get(slot="content")
+        plugin = add_plugin(placeholder, "TextPlugin", "en", body="Initial safe text")
 
         with CaptureQueriesContext(connection) as queries:
-            add_plugin(placeholder, "TextPlugin", "en", body="Regular safe text")
+            plugin.body = "Regular safe text"
+            plugin.save(update_fields={"body"})
 
         text_table = connection.ops.quote_name(Text._meta.db_table)
         text_writes = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.template import RequestContext
 from django.utils.encoding import force_str
 from django.utils.html import escape
@@ -1028,6 +1030,21 @@ class PluginActionsTestCase(TestFixture, BaseTestCase):
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(self.reload(plugin).body, "<div>divcontent</div><a>acontent</a>")
+
+    def test_safe_text_plugin_body_is_written_once(self):
+        page = self.create_page("test page", template="page.html", language="en")
+        placeholder = self.get_placeholders(page, "en").get(slot="content")
+
+        with CaptureQueriesContext(connection) as queries:
+            add_plugin(placeholder, "TextPlugin", "en", body="Regular safe text")
+
+        text_table = connection.ops.quote_name(Text._meta.db_table)
+        text_writes = [
+            query["sql"]
+            for query in queries
+            if query["sql"].lstrip().upper().startswith(("INSERT", "UPDATE")) and text_table in query["sql"]
+        ]
+        self.assertEqual(len(text_writes), 1, text_writes)
 
     def test_url_resolution(self):
         page = self.create_page("test page", template="page.html", language="en")


### PR DESCRIPTION
## Summary by Sourcery

Sanitize HTML content at persistence and form-clean stages to prevent stored XSS and ensure safe rendering, while tightening URL availability permissions and improving text plugin persistence behavior.

New Features:
- Sanitize HTML content when preparing values for HTMLField and when cleaning HTMLFormField and HTMLField inputs via a shared helper, ensuring only cleaned HTML is marked safe.
- Introduce ORM-level sanitization for HTMLField so unsafe updates through queryset.update are cleaned before storage.

Bug Fixes:
- Prevent stored XSS by cleaning HTML on HTMLField get_prep_value and ensuring all marked-safe values pass through the sanitizer.
- Ensure embedded image plugins and text plugin bodies are written to the database only once per save, avoiding redundant writes.
- Require the appropriate view permission for accessing available URLs in the text CMS plugin admin endpoint, preventing unauthorized access.
- Fix dynamic attribute resolution to correctly set element src attributes from get_absolute_url and to handle missing targets safely.

Enhancements:
- Refactor HTML sanitization and safe-marking into a reusable helper to centralize safety guarantees.
- Optimize dynamic object loading by using in_bulk in get_data_from_db and returning empty mappings on failure.
- Reuse a compiled image data regex across HTML helpers to avoid repeated compilation.

Tests:
- Add tests verifying safe text plugin bodies are persisted with a single database write.
- Add tests ensuring URL resolution in the admin endpoint requires the view_text permission.
- Add tests confirming model fields backed by HTMLField are sanitized on ORM updates.
- Update HTML dynamic attribute tests to use in_bulk for object lookup.